### PR TITLE
fix: APIキーテストのバグ修正と翻訳バーのstrongタグ表示修正

### DIFF
--- a/background.js
+++ b/background.js
@@ -317,7 +317,7 @@ async function fetchClaudeSummary(text, targetLang, apiKey) {
       'anthropic-dangerous-direct-browser-access': 'true',
     },
     body: JSON.stringify({
-      model: 'claude-3-5-sonnet-20241022',
+      model: 'claude-sonnet-4-5-20250514',
       max_tokens: 512,
       messages: [{
         role: 'user',
@@ -398,14 +398,18 @@ async function testApiKey(engine, apiKey) {
         'anthropic-dangerous-direct-browser-access': 'true',
       },
       body: JSON.stringify({
-        model: 'claude-3-5-sonnet-20241022',
+        model: 'claude-sonnet-4-5-20250514',
         max_tokens: 1,
         messages: [{ role: 'user', content: 'Hi' }],
       }),
     });
     if (!res.ok) {
+      // 401のみキー無効。400（残高不足等）や429（レート制限）は認証成功とみなす
       if (res.status === 401) throw new Error('APIキーが無効です');
-      throw new Error(`HTTP ${res.status}`);
+      if (res.status === 400 || res.status === 429) return;
+      let detail = '';
+      try { const err = await res.json(); detail = err.error?.message || ''; } catch(e) {}
+      throw new Error(`HTTP ${res.status}: ${detail}`);
     }
     return;
   }

--- a/content-bar.js
+++ b/content-bar.js
@@ -49,7 +49,18 @@ var DVT_BAR = (function () {
     bar.setAttribute('data-dvt', 'true');
     const barText = document.createElement('span');
     barText.className = 'dvt-translate-bar-text';
-    barText.textContent = t('translateBarMsg', { lang: langName });
+    // <strong>タグを含むメッセージをDOM要素に変換
+    const msgParts = t('translateBarMsg', { lang: langName }).split(/(<strong>.*?<\/strong>)/);
+    msgParts.forEach(part => {
+      const m = part.match(/^<strong>(.*)<\/strong>$/);
+      if (m) {
+        const strong = document.createElement('strong');
+        strong.textContent = m[1];
+        barText.appendChild(strong);
+      } else if (part) {
+        barText.appendChild(document.createTextNode(part));
+      }
+    });
     bar.appendChild(barText);
     const acceptBtn = document.createElement('button');
     acceptBtn.className = 'dvt-translate-bar-btn dvt-translate-bar-accept';

--- a/popup.js
+++ b/popup.js
@@ -60,6 +60,8 @@ chrome.storage.local.get(['targetLang', 'translateEngine', 'deeplApiKey', 'llmEn
   toggleLLMSettings();
   updateTranslateButtons();
   updateSummaryButtons();
+  // ストレージ読み込み後にテストボタンの状態を更新
+  updateApiTestButtons();
 });
 
 // ── UI言語変更 ───────────────────────────────────────────────────────
@@ -138,10 +140,17 @@ function toggleLLMSettings() {
 }
 
 // ── APIキー検証 ──────────────────────────────────────────────────────
+const apiTestButtons = [];
+
 function setupApiKeyTest(btnId, inputId, engine) {
   const btn = document.getElementById(btnId);
   const input = document.getElementById(inputId);
   if (!btn || !input) return;
+
+  function updateTestBtn() {
+    btn.disabled = !input.value.trim();
+  }
+  apiTestButtons.push(updateTestBtn);
 
   btn.addEventListener('click', () => {
     const apiKey = input.value.trim();
@@ -159,23 +168,25 @@ function setupApiKeyTest(btnId, inputId, engine) {
           btn.classList.add('dvt-test-ok');
         } else {
           btn.textContent = t('apiKeyInvalid');
+          btn.title = res?.error || '';
           btn.classList.add('dvt-test-ng');
         }
         btn.disabled = false;
         setTimeout(() => {
           btn.textContent = t('apiKeyTest');
           btn.classList.remove('dvt-test-ok', 'dvt-test-ng');
+          btn.title = '';
         }, 3000);
       }
     );
   });
 
-  // キー未入力時はボタン無効化
-  function updateTestBtn() {
-    btn.disabled = !input.value.trim();
-  }
   input.addEventListener('input', updateTestBtn);
-  updateTestBtn();
+}
+
+// ストレージ読み込み後に呼ぶ
+function updateApiTestButtons() {
+  apiTestButtons.forEach(fn => fn());
 }
 
 setupApiKeyTest('deeplTestBtn', 'deeplApiKey', 'deepl');


### PR DESCRIPTION
## Summary

- Claudeモデルを `claude-sonnet-4-5-20250514` に更新（旧モデル廃止対応）
- 残高不足(400)・レート制限(429)はキー有効と判定するように修正
- ストレージ読み込み後にテストボタンの状態を更新するよう修正
- 翻訳バーの `translateBarMsg` で `<strong>` タグが文字列表示されるデグレを修正
- テスト失敗時にエラー詳細をツールチップに表示

closes #29