### PR TITLE
fix: APIキーテストボタンのレイアウトを改善

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -141,21 +141,32 @@
       min-width: 42px;
     }
 
+    .dvt-api-key-wrap {
+      position: relative;
+      flex: 1;
+    }
+    .dvt-api-key-wrap input {
+      width: 100%;
+      padding-right: 54px;
+      box-sizing: border-box;
+    }
     .dvt-api-test-btn {
-      background: var(--bg3);
-      color: var(--text);
+      position: absolute;
+      right: 4px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: var(--bg2);
+      color: var(--muted);
       border: 1px solid var(--border);
-      border-radius: 7px;
-      padding: 4px 10px;
-      font-size: 11px;
+      border-radius: 5px;
+      padding: 2px 8px;
+      font-size: 10.5px;
       font-family: inherit;
       cursor: pointer;
       white-space: nowrap;
-      min-width: 56px;
-      text-align: center;
     }
-    .dvt-api-test-btn:hover { background: var(--bg2); }
-    .dvt-api-test-btn:disabled { opacity: 0.5; cursor: default; }
+    .dvt-api-test-btn:hover { color: var(--text); background: var(--bg3); }
+    .dvt-api-test-btn:disabled { opacity: 0.4; cursor: default; }
     .dvt-api-test-btn.dvt-test-ok { color: #22c55e; border-color: #22c55e; }
     .dvt-api-test-btn.dvt-test-ng { color: #ef4444; border-color: #ef4444; }
 
@@ -585,8 +596,10 @@
       <div id="deeplSettings" style="display:none; margin-top: 8px;">
         <div class="lang-row">
           <span class="lang-label" data-i18n="deeplApiKeyLabel">APIキー</span>
-          <input type="password" id="deeplApiKey" data-i18n-placeholder="deeplApiKeyPlaceholder" placeholder="APIキーを入力" style="flex:1; background:var(--bg3); color:var(--text); border:1px solid var(--border); border-radius:7px; padding:6px 10px; font-size:12.5px; font-family:inherit; outline:none;">
-          <button class="dvt-api-test-btn" id="deeplTestBtn" data-i18n="apiKeyTest">テスト</button>
+          <div class="dvt-api-key-wrap">
+            <input type="password" id="deeplApiKey" data-i18n-placeholder="deeplApiKeyPlaceholder" placeholder="APIキーを入力" style="background:var(--bg3); color:var(--text); border:1px solid var(--border); border-radius:7px; padding:6px 10px; font-size:12.5px; font-family:inherit; outline:none;">
+            <button class="dvt-api-test-btn" id="deeplTestBtn" data-i18n="apiKeyTest">テスト</button>
+          </div>
         </div>
       </div>
     </div>
@@ -603,15 +616,19 @@
       <div id="claudeSettings" style="display:none; margin-top: 8px;">
         <div class="lang-row">
           <span class="lang-label" data-i18n="claudeApiKeyLabel">APIキー</span>
-          <input type="password" id="claudeApiKey" data-i18n-placeholder="claudeApiKeyPlaceholder" placeholder="Claude APIキーを入力" style="flex:1; background:var(--bg3); color:var(--text); border:1px solid var(--border); border-radius:7px; padding:6px 10px; font-size:12.5px; font-family:inherit; outline:none;">
-          <button class="dvt-api-test-btn" id="claudeTestBtn" data-i18n="apiKeyTest">テスト</button>
+          <div class="dvt-api-key-wrap">
+            <input type="password" id="claudeApiKey" data-i18n-placeholder="claudeApiKeyPlaceholder" placeholder="Claude APIキーを入力" style="background:var(--bg3); color:var(--text); border:1px solid var(--border); border-radius:7px; padding:6px 10px; font-size:12.5px; font-family:inherit; outline:none;">
+            <button class="dvt-api-test-btn" id="claudeTestBtn" data-i18n="apiKeyTest">テスト</button>
+          </div>
         </div>
       </div>
       <div id="geminiSettings" style="display:none; margin-top: 8px;">
         <div class="lang-row">
           <span class="lang-label" data-i18n="geminiApiKeyLabel">APIキー</span>
-          <input type="password" id="geminiApiKey" data-i18n-placeholder="geminiApiKeyPlaceholder" placeholder="Gemini APIキーを入力" style="flex:1; background:var(--bg3); color:var(--text); border:1px solid var(--border); border-radius:7px; padding:6px 10px; font-size:12.5px; font-family:inherit; outline:none;">
-          <button class="dvt-api-test-btn" id="geminiTestBtn" data-i18n="apiKeyTest">テスト</button>
+          <div class="dvt-api-key-wrap">
+            <input type="password" id="geminiApiKey" data-i18n-placeholder="geminiApiKeyPlaceholder" placeholder="Gemini APIキーを入力" style="background:var(--bg3); color:var(--text); border:1px solid var(--border); border-radius:7px; padding:6px 10px; font-size:12.5px; font-family:inherit; outline:none;">
+            <button class="dvt-api-test-btn" id="geminiTestBtn" data-i18n="apiKeyTest">テスト</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 関連Issue

Closes hirokatsuhibino/dualview-translator#31

## 変更内容

- テストボタンをinputフィールド内の右端に `position: absolute` で配置
- `.dvt-api-key-wrap` ラッパーを追加し、inputとボタンをまとめて管理
- inputに `padding-right: 54px` を確保してボタンと文字が重ならないように調整
- DeepL / Claude / Gemini の3箇所すべてに適用

## 確認方法

1. 拡張を再読み込み
2. ポップアップの設定タブを開く
3. 翻訳エンジンをDeepLに変更、またはLLMエンジンを選択
4. APIキー入力フィールドの右端に「テスト」ボタンが横スクロールなしで見えることを確認
5. テストボタンの動作（検証中→有効/無効表示）が正常に動くことを確認