### PR TITLE
feat: Safari/iOS互換のための土台対応（Phase 1-2）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ LLM（Claude / Gemini）による要約機能も搭載。
 │   ├── content-page.test.js #  content-page テスト（10件）
 │   ├── content-bar.test.js #   content-bar テスト（17件）
 │   ├── content-selection.test.js # content-selection テスト（9件）
-│   └── background.test.js  #  background テスト（18件）
+│   ├── background.test.js  #  background テスト（18件）
+│   └── safari-compat.test.js # Safari/iOS互換テスト（8件）
 └── docs/                  # 公開資料
     ├── chrome-web-store.md #   Chrome Web Store掲載用テキスト
     ├── RELEASE_NOTES.md   #   リリースノート

--- a/background.js
+++ b/background.js
@@ -31,35 +31,42 @@ function isTranslateAvailable(data) {
   return data.translateEngine !== 'deepl' || !!data.deeplApiKey;
 }
 
+// ─── 機能検出フラグ（iOS Safariはcontextual menu / commands非対応） ──
+const HAS_CONTEXT_MENUS = typeof chrome.contextMenus !== 'undefined';
+const HAS_COMMANDS = typeof chrome.commands !== 'undefined';
+
 // ─── コンテキストメニュー登録 ─────────────────────────────────────────
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.get(['uiLang', 'claudeApiKey', 'geminiApiKey', 'translateEngine', 'deeplApiKey'], (data) => {
-    const titles = getMenuTitles(data.uiLang || 'ja');
-    const llmEnabled = hasLLMApiKey(data);
-    const translateEnabled = isTranslateAvailable(data);
-    chrome.contextMenus.create({
-      id: 'dvt-translate-selection',
-      title: titles.selection,
-      contexts: ['selection'],
-      enabled: translateEnabled,
-    });
-    chrome.contextMenus.create({
-      id: 'dvt-translate-element',
-      title: titles.element,
-      contexts: ['page', 'frame', 'link', 'image', 'video', 'audio'],
-      enabled: translateEnabled,
-    });
-    chrome.contextMenus.create({
-      id: 'dvt-translate-summarize-element',
-      title: titles.elementSummary,
-      contexts: ['page', 'frame', 'link', 'image', 'video', 'audio'],
-      enabled: translateEnabled && llmEnabled,
+if (HAS_CONTEXT_MENUS) {
+  chrome.runtime.onInstalled.addListener(() => {
+    chrome.storage.local.get(['uiLang', 'claudeApiKey', 'geminiApiKey', 'translateEngine', 'deeplApiKey'], (data) => {
+      const titles = getMenuTitles(data.uiLang || 'ja');
+      const llmEnabled = hasLLMApiKey(data);
+      const translateEnabled = isTranslateAvailable(data);
+      chrome.contextMenus.create({
+        id: 'dvt-translate-selection',
+        title: titles.selection,
+        contexts: ['selection'],
+        enabled: translateEnabled,
+      });
+      chrome.contextMenus.create({
+        id: 'dvt-translate-element',
+        title: titles.element,
+        contexts: ['page', 'frame', 'link', 'image', 'video', 'audio'],
+        enabled: translateEnabled,
+      });
+      chrome.contextMenus.create({
+        id: 'dvt-translate-summarize-element',
+        title: titles.elementSummary,
+        contexts: ['page', 'frame', 'link', 'image', 'video', 'audio'],
+        enabled: translateEnabled && llmEnabled,
+      });
     });
   });
-});
+}
 
 // ─── UI言語変更・APIキー変更時にメニューを更新 ──────────────────────
 chrome.storage.onChanged.addListener((changes) => {
+  if (!HAS_CONTEXT_MENUS) return;
   if (changes.uiLang) {
     const titles = getMenuTitles(changes.uiLang.newValue);
     chrome.contextMenus.update('dvt-translate-selection', { title: titles.selection });
@@ -88,46 +95,50 @@ chrome.storage.onChanged.addListener((changes) => {
 });
 
 // ─── コンテキストメニュークリック ─────────────────────────────────────
-chrome.contextMenus.onClicked.addListener((info, tab) => {
-  if (!tab?.id) return;
-  if (info.menuItemId === 'dvt-translate-selection' && info.selectionText) {
-    chrome.tabs.sendMessage(tab.id, {
-      action: 'contextMenuTranslate',
-      text: info.selectionText,
-    });
-  }
-  if (info.menuItemId === 'dvt-translate-element') {
-    chrome.tabs.sendMessage(tab.id, {
-      action: 'contextMenuTranslateElement',
-    });
-  }
-  if (info.menuItemId === 'dvt-translate-summarize-element') {
-    chrome.tabs.sendMessage(tab.id, {
-      action: 'contextMenuTranslateAndSummarize',
-    });
-  }
-});
+if (HAS_CONTEXT_MENUS) {
+  chrome.contextMenus.onClicked.addListener((info, tab) => {
+    if (!tab?.id) return;
+    if (info.menuItemId === 'dvt-translate-selection' && info.selectionText) {
+      chrome.tabs.sendMessage(tab.id, {
+        action: 'contextMenuTranslate',
+        text: info.selectionText,
+      });
+    }
+    if (info.menuItemId === 'dvt-translate-element') {
+      chrome.tabs.sendMessage(tab.id, {
+        action: 'contextMenuTranslateElement',
+      });
+    }
+    if (info.menuItemId === 'dvt-translate-summarize-element') {
+      chrome.tabs.sendMessage(tab.id, {
+        action: 'contextMenuTranslateAndSummarize',
+      });
+    }
+  });
+}
 
 // ─── キーボードショートカット ─────────────────────────────────────────
-chrome.commands.onCommand.addListener(async (command) => {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!tab?.id) return;
+if (HAS_COMMANDS) {
+  chrome.commands.onCommand.addListener(async (command) => {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) return;
 
-  if (command === 'toggle-page-translate') {
-    chrome.storage.local.get('targetLang', (data) => {
-      chrome.tabs.sendMessage(tab.id, {
-        action: 'togglePageTranslate',
-        lang: data.targetLang || 'ja',
+    if (command === 'toggle-page-translate') {
+      chrome.storage.local.get('targetLang', (data) => {
+        chrome.tabs.sendMessage(tab.id, {
+          action: 'togglePageTranslate',
+          lang: data.targetLang || 'ja',
+        });
       });
-    });
-  }
-  if (command === 'translate-selection') {
-    chrome.tabs.sendMessage(tab.id, { action: 'keyboardTranslateSelection' });
-  }
-  if (command === 'enter-region-mode') {
-    chrome.tabs.sendMessage(tab.id, { action: 'enterRegionMode' });
-  }
-});
+    }
+    if (command === 'translate-selection') {
+      chrome.tabs.sendMessage(tab.id, { action: 'keyboardTranslateSelection' });
+    }
+    if (command === 'enter-region-mode') {
+      chrome.tabs.sendMessage(tab.id, { action: 'enterRegionMode' });
+    }
+  });
+}
 
 // ─── メッセージハンドラ ──────────────────────────────────────────────
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {

--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,7 @@
     "https://api-free.deepl.com/*",
     "https://api.deepl.com/*",
     "https://api.anthropic.com/*",
-    "https://generativelanguage.googleapis.com/*",
-    "<all_urls>"
+    "https://generativelanguage.googleapis.com/*"
   ],
   "action": {
     "default_popup": "popup.html",

--- a/popup-init.js
+++ b/popup-init.js
@@ -25,3 +25,11 @@
     });
   }
 })();
+
+// iOS Safari等 chrome.commands 非対応環境ではショートカット表示を隠す
+(function() {
+  var hasCommands = typeof chrome !== 'undefined' && typeof chrome.commands !== 'undefined';
+  if (!hasCommands) {
+    document.documentElement.classList.add('dvt-no-shortcuts');
+  }
+})();

--- a/popup.html
+++ b/popup.html
@@ -247,6 +247,10 @@
       letter-spacing: 0.03em;
     }
 
+    /* iOS Safari等ショートカット非対応環境で表示を隠す */
+    :root.dvt-no-shortcuts .btn-shortcut,
+    :root.dvt-no-shortcuts #shortcutInfoRow { display: none !important; }
+
     /* ── Status ── */
     .status-bar {
       padding: 10px 18px;
@@ -661,8 +665,8 @@
     <div class="section">
       <div class="info-box">
         <span data-i18n="selectionTip" data-i18n-html>選択翻訳：ページ上でテキストを選択すると、自動的に翻訳パネルが表示されます。</span><br>
-        <span data-i18n="engineInfo" data-i18n-html>翻訳エンジン：Google 翻訳（無料）</span><br>
-        <span data-i18n="shortcutInfo" data-i18n-html>ショートカット：Ctrl+Shift+T（ページ翻訳）/ Ctrl+Shift+Y（選択翻訳）/ Ctrl+Shift+R（領域選択）</span>
+        <span data-i18n="engineInfo" data-i18n-html>翻訳エンジン：Google 翻訳（無料）</span>
+        <span id="shortcutInfoRow"><br><span data-i18n="shortcutInfo" data-i18n-html>ショートカット：Ctrl+Shift+T（ページ翻訳）/ Ctrl+Shift+Y（選択翻訳）/ Ctrl+Shift+R（領域選択）</span></span>
       </div>
     </div>
   </div>

--- a/tests/safari-compat.test.js
+++ b/tests/safari-compat.test.js
@@ -1,0 +1,120 @@
+// Copyright (c) Orangesoft Inc
+// Safari / iOS Safari 互換性テスト
+// - contextMenus / commands が未定義でも background.js が起動できる
+// - popup-init.js が commands 未定義時に dvt-no-shortcuts クラスを付与する
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const bgPath = resolve(import.meta.dirname, '..', 'background.js');
+const popupInitPath = resolve(import.meta.dirname, '..', 'popup-init.js');
+
+// background.js の top-level をサンドボックス内で実行する
+// （chrome オブジェクトを差し替えてSafari/iOS環境を模擬）
+function runBackground(chromeStub) {
+  const code = readFileSync(bgPath, 'utf-8');
+  const fn = new Function('chrome', 'fetch', code);
+  fn(chromeStub, () => Promise.resolve({ ok: true, json: () => ({}) }));
+}
+
+function makeChromeStub({ contextMenus, commands } = {}) {
+  const stub = {
+    runtime: {
+      onInstalled: { addListener: () => {} },
+      onMessage: { addListener: () => {} },
+      lastError: null,
+    },
+    storage: {
+      local: {
+        get: (_k, cb) => cb && cb({}),
+        set: (_d, cb) => cb && cb(),
+      },
+      onChanged: { addListener: () => {} },
+    },
+    tabs: {
+      query: () => Promise.resolve([]),
+      sendMessage: () => Promise.resolve({ ok: true }),
+    },
+  };
+  if (contextMenus) {
+    stub.contextMenus = {
+      create: () => {},
+      update: () => {},
+      onClicked: { addListener: () => {} },
+    };
+  }
+  if (commands) {
+    stub.commands = {
+      onCommand: { addListener: () => {} },
+    };
+  }
+  return stub;
+}
+
+describe('background.js Safari / iOS 互換', () => {
+  it('chrome.contextMenus / chrome.commands 両方が存在しても例外が出ない（macOS Safari想定）', () => {
+    expect(() => runBackground(makeChromeStub({ contextMenus: true, commands: true }))).not.toThrow();
+  });
+
+  it('chrome.contextMenus が未定義でも例外が出ない（iOS Safari想定）', () => {
+    expect(() => runBackground(makeChromeStub({ contextMenus: false, commands: false }))).not.toThrow();
+  });
+
+  it('chrome.commands のみ未定義でも例外が出ない', () => {
+    expect(() => runBackground(makeChromeStub({ contextMenus: true, commands: false }))).not.toThrow();
+  });
+
+  it('chrome.contextMenus のみ未定義でも例外が出ない', () => {
+    expect(() => runBackground(makeChromeStub({ contextMenus: false, commands: true }))).not.toThrow();
+  });
+});
+
+describe('popup-init.js Safari / iOS 互換', () => {
+  let originalCommands;
+
+  beforeEach(() => {
+    // 初期化前に documentElement のクラスをリセット
+    document.documentElement.className = '';
+    originalCommands = globalThis.chrome.commands;
+  });
+
+  afterEach(() => {
+    globalThis.chrome.commands = originalCommands;
+    document.documentElement.className = '';
+  });
+
+  function runPopupInit() {
+    const code = readFileSync(popupInitPath, 'utf-8');
+    const fn = new Function(code);
+    fn();
+  }
+
+  it('chrome.commands が存在する場合は dvt-no-shortcuts クラスを付与しない', () => {
+    runPopupInit();
+    expect(document.documentElement.classList.contains('dvt-no-shortcuts')).toBe(false);
+  });
+
+  it('chrome.commands が未定義の場合は dvt-no-shortcuts クラスを付与する（iOS Safari想定）', () => {
+    delete globalThis.chrome.commands;
+    runPopupInit();
+    expect(document.documentElement.classList.contains('dvt-no-shortcuts')).toBe(true);
+  });
+});
+
+describe('manifest.json Safari 互換', () => {
+  it('host_permissions から <all_urls> を除去済み', () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '..', 'manifest.json'), 'utf-8')
+    );
+    expect(manifest.host_permissions).not.toContain('<all_urls>');
+  });
+
+  it('翻訳・要約エンジンのAPIホストはhost_permissionsに残っている', () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '..', 'manifest.json'), 'utf-8')
+    );
+    expect(manifest.host_permissions).toContain('https://translate.googleapis.com/*');
+    expect(manifest.host_permissions).toContain('https://api.anthropic.com/*');
+    expect(manifest.host_permissions).toContain('https://generativelanguage.googleapis.com/*');
+  });
+});


### PR DESCRIPTION
## Summary

Safari / iOS Safari対応の Phase 1（manifest調整）と Phase 2（iOS機能フォールバック）。
Chrome / Firefox の動作は維持したまま、Safari で読み込めない API を参照しても落ちないように修正。

### 変更内容

**Phase 1 — manifest.json**
- `host_permissions` から `<all_urls>` を削除
  - 翻訳/要約API（Google/DeepL/Claude/Gemini）の各ホストは引き続き明示
  - content_scripts の `matches: <all_urls>` は機能上必要なので維持
  - Chrome Web Store 審査・Safari App Store 審査での指摘リスクを低減

**Phase 2 — feature detection**
- `background.js`: `chrome.contextMenus` / `chrome.commands` の存在チェックを追加
  - iOS Safari は両方未提供。参照時に `TypeError` で Service Worker が死ぬのを防ぐ
- `popup-init.js`: `chrome.commands` 未定義のとき `<html>` に `dvt-no-shortcuts` クラスを付与
- `popup.html`: CSS で `.dvt-no-shortcuts` 下のショートカット表示を非表示化
  - ボタン内の `Ctrl+Shift+T` 等の小さな表示
  - 設定タブ最下部の「ショートカット：...」行

**テスト**
- `tests/safari-compat.test.js`（8件）を追加
  - `chrome.contextMenus` / `chrome.commands` 欠落時に background.js が例外を投げない
  - `chrome.commands` 未定義時に popup-init.js が `dvt-no-shortcuts` クラスを付与
  - `manifest.json` から `<all_urls>` host_permission が削除されている
- 全 185 件パス（従来 177 件 + 新規 8 件）

### まだやっていない（Phase 3-4）

- Xcode プロジェクト生成（`safari-web-extension-converter`）
- macOS/iOS ターゲットの追加
- README・リリースノートへのインストール手順追加

別PRで対応予定。

refs #1