### PR TITLE
feat: Claude 要約モデルを Haiku に変更してコスト削減

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ content-*.js → chrome.runtime.sendMessage → background.js → Google Transla
 
 ### 要約エンジン（LLM）
 
-- **Claude**: `api.anthropic.com/v1/messages`（model: claude-3-5-sonnet-20241022）
+- **Claude**: `api.anthropic.com/v1/messages`（model: claude-haiku-4-5-20251001）
 - **Gemini**: `generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash`
 - 切り替え: `chrome.storage.local` の `llmEngine` / `claudeApiKey` / `geminiApiKey` で管理
 - 選択エンジンのAPIキーが未設定の場合、もう一方に自動フォールバック

--- a/background.js
+++ b/background.js
@@ -481,7 +481,7 @@ async function fetchClaudeSummary(text, targetLang, apiKey) {
       'anthropic-dangerous-direct-browser-access': 'true',
     },
     body: JSON.stringify({
-      model: 'claude-sonnet-4-5-20250514',
+      model: 'claude-haiku-4-5-20251001',
       max_tokens: 512,
       messages: [{
         role: 'user',
@@ -562,7 +562,7 @@ async function testApiKey(engine, apiKey) {
         'anthropic-dangerous-direct-browser-access': 'true',
       },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-5-20250514',
+        model: 'claude-haiku-4-5-20251001',
         max_tokens: 1,
         messages: [{ role: 'user', content: 'Hi' }],
       }),

--- a/background.js
+++ b/background.js
@@ -212,6 +212,9 @@ const SC_MAX_ENTRIES = 500; // 要約は1件あたりのデータ量が多いた
 const SC_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30日
 const SC_EVICT_RATIO = 0.1; // 超過時に古い順 10% を削除
 
+// ─── Claude 要約モデル ────────────────────────────────────────────────
+const CLAUDE_SUMMARY_MODEL = 'claude-haiku-4-5-20251001';
+
 // chrome.storage.local の Promise ラッパー（callback-only 環境でも動作）
 const storageGet = (keys) => new Promise(resolve => chrome.storage.local.get(keys, resolve));
 const storageSet = (items) => new Promise(resolve => chrome.storage.local.set(items, resolve));
@@ -481,7 +484,7 @@ async function fetchClaudeSummary(text, targetLang, apiKey) {
       'anthropic-dangerous-direct-browser-access': 'true',
     },
     body: JSON.stringify({
-      model: 'claude-haiku-4-5-20251001',
+      model: CLAUDE_SUMMARY_MODEL,
       max_tokens: 512,
       messages: [{
         role: 'user',
@@ -562,15 +565,29 @@ async function testApiKey(engine, apiKey) {
         'anthropic-dangerous-direct-browser-access': 'true',
       },
       body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
+        model: CLAUDE_SUMMARY_MODEL,
         max_tokens: 1,
         messages: [{ role: 'user', content: 'Hi' }],
       }),
     });
     if (!res.ok) {
-      // 401のみキー無効。400（残高不足等）や429（レート制限）は認証成功とみなす
       if (res.status === 401) throw new Error('APIキーが無効です');
-      if (res.status === 400 || res.status === 429) return;
+      if (res.status === 429) return; // レート制限はキー有効とみなす
+      if (res.status === 400) {
+        // レスポンスボディでモデル不明エラーを判別（それ以外の400は認証とは無関係なのでキー有効扱い）
+        let errType = '';
+        let errMsg = '';
+        try {
+          const errJson = await res.json();
+          errType = errJson.error?.type || '';
+          errMsg = errJson.error?.message || '';
+        } catch(e) {}
+        // model_not_found など、モデル名誤りが原因の場合はキー有効とみなさない
+        if (errType === 'not_found_error' || /model/i.test(errMsg)) {
+          throw new Error(`APIキー検証エラー: モデルが見つかりません (${errMsg})`);
+        }
+        return; // 残高不足・その他の400はキー有効とみなす
+      }
       let detail = '';
       try { const err = await res.json(); detail = err.error?.message || ''; } catch(e) {}
       throw new Error(`HTTP ${res.status}: ${detail}`);


### PR DESCRIPTION
## Summary

- `fetchClaudeSummary()` と `testApiKey()` の Claude モデルを変更
  - `claude-sonnet-4-5-20250514` → `claude-haiku-4-5-20251001`
- Haiku は Sonnet の約 1/10 のコスト。要約タスクには十分な品質が期待できる
- `CLAUDE.md` のモデル記述も更新

closes #62