### PR TITLE
docs: リリーススキルをフルフロー対応に更新

### DIFF
--- a/.claude/skills/build-zip.md
+++ b/.claude/skills/build-zip.md
@@ -21,6 +21,8 @@ Chrome Web Store / Firefox Add-ons 向けの公開用zipと、
 node -p "require('./manifest.json').version"
 ```
 
+以降 `<VERSION>` をこの値で置き換える。
+
 ### 2. 既存zipを削除
 
 ```bash
@@ -29,6 +31,7 @@ rm -f dualview-translator-*.zip
 
 ### 3. 公開用zip（拡張本体）を作成
 
+Chrome Web Store / Firefox Add-ons への提出用。
 ファイル名: `dualview-translator-<VERSION>.zip`
 
 含めるファイル:
@@ -65,15 +68,27 @@ zip -r dualview-translator-<VERSION>.zip \
 
 ### 4. ソースコードアーカイブを作成（Firefox審査用）
 
+Firefox Add-ons の審査では、ビルドが不要な場合でもソースコードの提出が求められることがある。
 ファイル名: `dualview-translator-<VERSION>-source.zip`
 
-除外するもの: `node_modules/`, `.git/`, `*.zip`
+除外するもの:
+- `node_modules/` — 依存パッケージ（`npm install` で復元可能）
+- `.git/` — gitリポジトリ内部データ
+- `safari/` — Safari向けXcodeプロジェクト（Firefox審査対象外）
+- `.claude/` — AI開発支援ツール設定
+- `dualview-translator-*.zip` — 既存zipが混入しないよう除外
+- `docs/sample-after.png`, `docs/popup.png`, `docs/sample-afterのコピー.png` — スクリーンショット一時ファイル
 
 ```bash
 zip -r dualview-translator-<VERSION>-source.zip . \
+  -x "*.git*" \
   -x "node_modules/*" \
-  -x ".git/*" \
-  -x "*.zip"
+  -x "safari/*" \
+  -x ".claude/*" \
+  -x "dualview-translator-*.zip" \
+  -x "docs/sample-after.png" \
+  -x "docs/popup.png" \
+  -x "docs/sample-afterのコピー.png"
 ```
 
 ### 5. 生成物を確認
@@ -94,5 +109,6 @@ ls -lh dualview-translator-*.zip
 ## ルール
 
 - バージョンは必ず `manifest.json` から取得する（手入力しない）
-- 既存のzipは上書き前に削除する
-- 新しいファイルが追加された場合はこのスキルの含めるファイルリストも更新する
+- 既存のzipは作成前に削除する（古いバージョンが残らないよう）
+- 新しいソースファイルが追加された場合は、公開用zipの含めるファイルリストも更新する
+- zipファイル自体は git に含めない

--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -1,6 +1,6 @@
 ---
 name: リリース
-description: バージョン更新→zip作成→コミット→pushの一連のリリースフローを実行
+description: バージョン更新→リリースノート整備→PR→タグ→GitHub Release→zipアップロードの一連のリリースフローを実行
 user_invocable: true
 ---
 
@@ -8,62 +8,164 @@ user_invocable: true
 
 ## 概要
 
-バージョンを上げて、公開用zipを作成し、コミット＆pushする一連のリリースフローを実行する。
+バージョンを上げ、リリースノートを整備し、PR経由でmainにマージ後、
+git tag・GitHub Release作成・zip添付まで一連のリリースフローを実行する。
 
 ## 手順
 
-### 1. 現在のバージョンを確認
+### 1. 現在のバージョンと未リリース内容を確認
 
 ```bash
 node -p "require('./manifest.json').version"
 ```
 
-### 2. バージョンを更新
+`docs/RELEASE_NOTES.md` の `## 未リリース` セクションを確認して変更内容をまとめる。
 
-パッチバージョンを上げる（例: 1.2.2 → 1.2.3）。メジャー/マイナー変更はユーザーに確認する。
+### 2. 新バージョンを決定
 
-更新対象:
+バージョニング規則（Semantic Versioning）:
+- `PATCH`（x.x.**N**）: バグ修正のみ
+- `MINOR`（x.**N**.0）: 新機能追加（後方互換あり）← 複数の新機能がある場合
+- `MAJOR`（**N**.0.0）: 破壊的変更
+
+判断に迷う場合はユーザーに確認する。
+
+### 3. リリースブランチを作成
+
+```bash
+git checkout -b release/v<VERSION>
+```
+
+### 4. バージョン番号を更新
+
+更新対象（必ず両方同期させる）:
 - `manifest.json` の `version`
 - `package.json` の `version`
 
-### 3. リリースノート更新
+### 5. リリースノートを更新
 
-`docs/RELEASE_NOTES.md` の先頭（`## v1.x.x` の前）に新バージョンのセクションを追加する。
+`docs/RELEASE_NOTES.md` を以下のように編集する:
 
-- 前回リリースからの `git log` を確認して変更内容をまとめる
-- フォーマットは既存エントリに合わせる（`## v<VERSION>（YYYY-MM-DD）` + カテゴリ別リスト）
-- カテゴリ: `新機能` / `改善` / `修正` を内容に応じて使い分ける
+1. `## 未リリース` セクションの内容を `## v<VERSION>（YYYY-MM-DD）` セクションに移動
+2. Claude Haiku などモデル変更・改善も漏れなく記載する
+3. `## 未リリース` セクションを空欄で残す（次のリリース用）
 
-### 4. zip作成
+フォーマット:
+```markdown
+## 未リリース
 
-`/skill build-zip` を使用して公開用zipとソースコードアーカイブを作成する。
+---
 
-### 5. コミット & Push & PR作成
+## v<VERSION>（YYYY-MM-DD）
 
-対応するIssueがなければ作成し、PRで `closes #<番号>` を含める。
+### 新機能
+- ...
+
+### 改善
+- ...
+
+### 修正
+- ...
+```
+
+カテゴリは内容に応じて使い分ける。該当なしのカテゴリは省略可。
+
+### 6. テストを実行
+
+```bash
+npm test
+```
+
+全件パスを確認してから次へ進む。
+
+### 7. コミット・push・PR作成
 
 ```bash
 git add manifest.json package.json docs/RELEASE_NOTES.md
-git commit -m "$(cat <<'EOF'
-chore: バージョンを<VERSION>に更新
-
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
-EOF
-)"
-git push -u origin <branch>
-gh pr create --title "chore: バージョンを<VERSION>に更新" --body "$(cat <<'EOF'
+git commit -m "chore: v<VERSION> リリース準備（バージョン番号更新・リリースノート整備）"
+git push -u origin release/v<VERSION>
+gh pr create \
+  --title "chore: v<VERSION> リリース準備" \
+  --body "$(cat <<'EOF'
 ## Summary
-- バージョンを<VERSION>に更新
-- リリースノート追加
 
-closes #<番号>
+- `manifest.json` / `package.json`: バージョンを <OLD> → **<VERSION>** に更新
+- `docs/RELEASE_NOTES.md`: 未リリース機能を v<VERSION> としてまとめ
+
+## v<VERSION> の主な変更
+
+### 新機能
+- ...
+
+### 改善
+- ...
 EOF
 )"
+```
+
+### 8. PRをマージしてブランチを削除
+
+```bash
+gh pr merge <PR番号> --repo hirokatsuhibino/dualview-translator --merge
+git checkout main && git pull
+git branch -d release/v<VERSION>
+git push origin --delete release/v<VERSION>
+```
+
+### 9. git タグを打つ
+
+```bash
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+### 10. GitHub Release を作成
+
+```bash
+gh release create v<VERSION> \
+  --repo hirokatsuhibino/dualview-translator \
+  --title "v<VERSION>" \
+  --notes "$(cat <<'EOF'
+## 新機能
+- ...
+
+## 改善
+- ...
+
+## 修正
+- ...
+
+---
+
+Copyright (c) Orangesoft Inc.
+EOF
+)"
+```
+
+`--notes` の内容はリリースノートの該当バージョンセクションから転記する。
+
+### 11. zip を作成して GitHub Release にアップロード
+
+`/skill build-zip` を実行してから:
+
+```bash
+gh release upload v<VERSION> \
+  dualview-translator-<VERSION>.zip \
+  dualview-translator-<VERSION>-source.zip \
+  --repo hirokatsuhibino/dualview-translator
+```
+
+アップロード結果を確認:
+
+```bash
+gh release view v<VERSION> --repo hirokatsuhibino/dualview-translator \
+  --json assets --jq '.assets[] | {name, size: (.size / 1024 | floor | tostring) + "KB"}'
 ```
 
 ## ルール
 
 - バージョンは `manifest.json` と `package.json` の両方を必ず同期させる
-- zipファイルはgitに含めない
-- コミットメッセージは `chore: バージョンを<VERSION>に更新` の形式
-- mainへの直接pushは禁止。必ずPR経由でマージする
+- zipファイルは git に含めない（`.gitignore` 済み）
+- mainへの直接pushは禁止。必ず `release/v<VERSION>` ブランチ → PR → マージ の流れで行う
+- コミットメッセージは `chore: v<VERSION> リリース準備（バージョン番号更新・リリースノート整備）` の形式
+- GitHub Release の notes は日本語で記述する


### PR DESCRIPTION
## Summary

- `.claude/skills/release.md`: リリースブランチ作成→PR→マージ→タグ→GitHub Release作成→zipアップロードまでのフルフローに更新
- `.claude/skills/build-zip.md`: ソースアーカイブの除外パターンを実際の運用に合わせて整備（`.claude/`、`safari/`、スクリーンショット一時ファイルを追加）

v1.3.0 リリース作業で確立した手順をスキルに反映。