### PR TITLE
fix: CLAUDE.md のスキル/コマンド配置場所を正確に記述（PR #70 follow-up）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ content-*.js → chrome.runtime.sendMessage → background.js → Google Transla
   - `/pr-review-check` — オープンPRの未対応レビューを一括確認
   - `/release` — バージョン更新→リリースノート整備→PR→タグ→GitHub Release→zipアップロードのフルフロー
   - `/build-zip` — 公開用zip（拡張本体）とソースアーカイブ（Firefox審査用）を作成
+- 開発ワークフロー向けの Claude コマンドは `.claude/commands/` 配下に配置
   - `/pr-resume` — PR レビュー対応フローを手動再開
 
 ## 既知の問題


### PR DESCRIPTION
## Summary

PR #70 の Copilot レビュー指摘への follow-up 対応。

`/pr-resume` は `.claude/commands/` にあるにもかかわらず `.claude/skills/` の説明ブロックに含まれていた。
スキル（`skills/`）とコマンド（`commands/`）を分けて正確に記述するよう修正。