### PR TITLE
fix: ワークフローの ref 解決安全性強化とコメント修正（PR #71 follow-up）

### DIFF
--- a/.github/workflows/claude-pr-review-response.yml
+++ b/.github/workflows/claude-pr-review-response.yml
@@ -90,8 +90,8 @@ jobs:
           fi
 
           # イベント条件
-          #  - review.state が changes_requested
-          #  - review_comment / issue_comment は @claude メンション必須
+          #  - review.state が changes_requested → 即 proceed
+          #  - それ以外（review body / review_comment / issue_comment）は @claude メンション必須
           if [ "${EVENT_STATE:-}" = "changes_requested" ]; then
             proceed=true
           elif echo "${COMMENT_BODY:-}" | grep -q "@claude"; then
@@ -111,12 +111,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             # issue_comment は event から head.ref が取れないため gh で補完
             REF=$(gh pr view "${{ github.event.issue.number }}" --json headRefName --jq '.headRefName')
           else
             REF="${{ github.event.pull_request.head.ref }}"
           fi
+
+          if [ -z "${REF}" ]; then
+            echo "Failed to resolve PR head ref" >&2
+            exit 1
+          fi
+
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR head


### PR DESCRIPTION
## Summary

PR #71 の Copilot レビュー指摘への follow-up 対応。

| 指摘箇所 | 内容 | 対応 |
|----------|------|------|
| `yml:119` | `Resolve PR head ref` に strict mode と空 REF チェックなし | [done] `set -euo pipefail` + 空 REF 時に `exit 1` を追加 |
| `yml:98` | コメントが実装と不一致（`pull_request_review` も `@claude` で起動できるのに未記載） | [done] コメントを「review body 含む全イベントで @claude 必須（changes_requested 除く）」に修正 |