### PR TITLE
feat: プライバシーポリシー公開用に GitHub Pages を整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DualView Translator
 
-原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox 対応（Safari / iOS 対応は開発中）。
+原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox 対応（Safari / iOS は App Store 提出準備中）。
 
 翻訳しても原文が消えないので、原文を確認しながら読めます。
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -11,6 +11,18 @@
   - 拡張本体のブラウザ用アイコン（`icons/icon{16,32,48,128}.png`）も同じマスターから再生成
   - 元データを `assets/app-icon.svg` と再生成スクリプト `assets/generate-icons.py` としてリポジトリに保存
 
+- **Safari / iOS App Store 提出準備**（#75）
+  - macOS App / Extension に App Sandbox + Outgoing Connections capability を追加（Mac App Store 必須）
+  - iOS App Store ラージアイコンのアルファチャネルを削除（Apple のラージアイコン要件に対応）
+  - App Category を Productivity（仕事効率化）に設定
+  - 暗号化輸出規制申告（`ITSAppUsesNonExemptEncryption = NO`）を Info.plist に追加
+  - macOS / iOS ともに App Store Connect への Archive Upload が成功する状態に
+  - macOS Safari / iOS Safari 実機（TestFlight 経由）での動作確認完了
+
+- **プライバシーポリシーを GitHub Pages で公開**（#77）
+  - App Store 申請に必要な公開 URL を確保
+  - 公開 URL: `https://hirokatsuhibino.github.io/dualview-translator/privacy-policy.html`
+
 ---
 
 ## v1.3.0（2026-04-22）

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,23 @@
+# Copyright (c) Orangesoft Inc.
+# GitHub Pages (Jekyll) 設定
+# このディレクトリ内の公開対象を絞り込み、開発用ドキュメントを非公開にする。
+
+title: DualView Translator
+description: 原文と翻訳を並べて表示するブラウザ翻訳拡張
+url: https://hirokatsuhibino.github.io/dualview-translator
+
+# Jekyll のデフォルトテーマを有効化（Markdown を HTML にレンダリング）
+theme: jekyll-theme-cayman
+
+# 公開しないファイル（開発用ドキュメント）
+exclude:
+  - chrome-web-store.md
+  - firefox-add-ons.md
+  - permission-justification.md
+  - manual-test-scenarios.yaml
+  - test-plan.md
+  - store-icons
+  - sample-before.png
+  - sample-after.png
+  - sample-afterのコピー.png
+  - popup.png

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+<!--
+Copyright (c) Orangesoft Inc.
+-->
+# DualView Translator
+
+原文と翻訳を**並べて表示**するブラウザ翻訳拡張。
+
+## ドキュメント
+
+- [Privacy Policy](privacy-policy.html)
+- [Release Notes](RELEASE_NOTES.html)
+
+## リポジトリ
+
+ソースコードは GitHub で公開しています:
+[hirokatsuhibino/dualview-translator](https://github.com/hirokatsuhibino/dualview-translator)
+
+## 配布
+
+- Chrome: Chrome Web Store（準備中）
+- Firefox: Firefox Add-ons（準備中）
+- macOS / iOS Safari: Mac App Store / iOS App Store（準備中）


### PR DESCRIPTION
## Summary

- `docs/_config.yml` を追加し、Jekyll の公開対象を絞る（開発用ドキュメントは exclude）
- `docs/index.md` を追加（公開サイトのトップページ）
- `docs/RELEASE_NOTES.md` の「未リリース」に #75 および #77 の内容を追記
- `README.md` の Safari / iOS ステータスを「App Store 提出準備中」に更新

## 公開する／しないの整理

| ファイル | 公開 |
|---|---|
| `privacy-policy.md` | ✅ |
| `index.md` (新規) | ✅ |
| `RELEASE_NOTES.md` | ✅ |
| `chrome-web-store.md` / `firefox-add-ons.md` / `permission-justification.md` | ❌ |
| `manual-test-scenarios.yaml` / `test-plan.md` | ❌ |
| `store-icons/` / `sample-*.png` / `popup.png` | ❌ |

## マージ後の手動作業

リポジトリ Settings → Pages で以下を設定（人間操作）:
- Source: **Deploy from a branch**
- Branch: **main** / **/docs**

公開 URL（想定）:
- トップ: `https://hirokatsuhibino.github.io/dualview-translator/`
- プライバシーポリシー: `https://hirokatsuhibino.github.io/dualview-translator/privacy-policy.html`

## 検証

- Vitest: 9 files / **350 tests pass**
- `_config.yml` YAML 構文: OK

closes #77