### PR TITLE
fix: GitHub Pages の Markdown に Jekyll フロントマターを追加（PR #78 follow-up）

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+---
+title: Release Notes
+permalink: /RELEASE_NOTES.html
+---
+
 # リリースノート
 
 ## 未リリース

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+title: DualView Translator
+permalink: /index.html
+---
 <!--
 Copyright (c) Orangesoft Inc.
 -->

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,3 +1,8 @@
+---
+title: Privacy Policy
+permalink: /privacy-policy.html
+---
+
 # Privacy Policy — DualView Translator
 
 Last updated: 2026-04-17


### PR DESCRIPTION
## Summary

PR #78 の Copilot レビュー指摘に対応:

- `docs/index.md` / `docs/privacy-policy.md` / `docs/RELEASE_NOTES.md` に `title` + `permalink` フロントマターを追加
- `permalink` を明示することで、Jekyll 設定変更や将来の theme 変更があっても公開 URL が
  `/index.html`, `/privacy-policy.html`, `/RELEASE_NOTES.html` で固定される
- 現状 `_config.yml` の theme 指定により変換が動作しているが、予防的な明示化

## 現状の動作確認

PR #78 マージ後、以下が既に公開されて動作していることを確認済み:
- `https://hirokatsuhibino.github.io/dualview-translator/privacy-policy.html`

本 PR はその安定性をさらに高めるための予防的改善。

## 関連レビュー指摘

- [discussion_r3136141508](https://github.com/hirokatsuhibino/dualview-translator/pull/78#discussion_r3136141508)
- [discussion_r3136141549](https://github.com/hirokatsuhibino/dualview-translator/pull/78#discussion_r3136141549)
- [discussion_r3136141600](https://github.com/hirokatsuhibino/dualview-translator/pull/78#discussion_r3136141600)

本 PR のマージ後、上記インラインコメントに `[done]` 返信します。

closes #79