### PR TITLE
fix: macOS Safari で storage.local が Disk I/O error になる問題を修正

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,6 +7,13 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+### バグ修正
+
+- **macOS Safari で API キーや設定が保存されない問題を修正**（#81）
+  - PR #76 で App Sandbox を有効化した際、App Group entitlement が未設定だったため `storage.local` が `Disk I/O error` で失敗していた
+  - App / Extension 両方に App Group `group.jp.co.orangesoft.dualview-translator` を追加し、共有 Container にアクセスできるよう修正
+  - iOS 側にも予防的に同じ App Group を追加
+
 ### 改善
 
 - **App Store 提出向けの HD アプリアイコンを制作**（#49）

--- a/safari/DualView Translator/DualView Translator (iOS).entitlements
+++ b/safari/DualView Translator/DualView Translator (iOS).entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.jp.co.orangesoft.dualview-translator</string>
+	</array>
+</dict>
+</plist>

--- a/safari/DualView Translator/DualView Translator (macOS).entitlements
+++ b/safari/DualView Translator/DualView Translator (macOS).entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.jp.co.orangesoft.dualview-translator</string>
+	</array>
+</dict>
+</plist>

--- a/safari/DualView Translator/DualView Translator Extension (iOS).entitlements
+++ b/safari/DualView Translator/DualView Translator Extension (iOS).entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.jp.co.orangesoft.dualview-translator</string>
+	</array>
+</dict>
+</plist>

--- a/safari/DualView Translator/DualView Translator Extension (macOS).entitlements
+++ b/safari/DualView Translator/DualView Translator Extension (macOS).entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.jp.co.orangesoft.dualview-translator</string>
+	</array>
+</dict>
+</plist>

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -98,6 +98,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7D0D5AC12F9C3DE1005F61FC /* DualView Translator (iOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "DualView Translator (iOS).entitlements"; sourceTree = "<group>"; };
+		7D0D5AC22F9C3E04005F61FC /* DualView Translator (macOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "DualView Translator (macOS).entitlements"; sourceTree = "<group>"; };
+		7D0D5AC32F9C3E1B005F61FC /* DualView Translator Extension (iOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "DualView Translator Extension (iOS).entitlements"; sourceTree = "<group>"; };
+		7D0D5AC42F9C3E2F005F61FC /* DualView Translator Extension (macOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "DualView Translator Extension (macOS).entitlements"; sourceTree = "<group>"; };
 		7D1D47C62F95AD9300B65F5F /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/Main.html; sourceTree = "<group>"; };
 		7D1D47C72F95AD9300B65F5F /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon.png; sourceTree = "<group>"; };
 		7D1D47C82F95AD9300B65F5F /* Style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = Style.css; sourceTree = "<group>"; };
@@ -168,6 +172,10 @@
 		7D1D47BE2F95AD9300B65F5F = {
 			isa = PBXGroup;
 			children = (
+				7D0D5AC42F9C3E2F005F61FC /* DualView Translator Extension (macOS).entitlements */,
+				7D0D5AC32F9C3E1B005F61FC /* DualView Translator Extension (iOS).entitlements */,
+				7D0D5AC22F9C3E04005F61FC /* DualView Translator (macOS).entitlements */,
+				7D0D5AC12F9C3DE1005F61FC /* DualView Translator (iOS).entitlements */,
 				7D1D47C32F95AD9300B65F5F /* Shared (App) */,
 				7D1D47CC2F95AD9500B65F5F /* Shared (Extension) */,
 				7D1D47D42F95AD9500B65F5F /* iOS (App) */,
@@ -678,6 +686,7 @@
 		7D1D48112F95AD9500B65F5F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -712,6 +721,7 @@
 		7D1D48122F95AD9500B65F5F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -749,6 +759,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -791,6 +802,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -832,6 +844,7 @@
 		7D1D48182F95AD9500B65F5F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -865,6 +878,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.Extension";
 				PRODUCT_NAME = "DualView Translator Extension";
+				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -878,6 +892,7 @@
 		7D1D48192F95AD9500B65F5F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -911,6 +926,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.Extension";
 				PRODUCT_NAME = "DualView Translator Extension";
+				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -926,6 +942,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
@@ -970,6 +987,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;


### PR DESCRIPTION
## Summary

PR #76 で App Sandbox を有効化した際、**App Group entitlement** が未設定だったため、Safari Web Extension の \`storage.local\` が共有 Container にアクセスできず Disk I/O error で失敗していました。

その結果、API キー / 設定 / 自動翻訳ルール / 翻訳キャッシュ / 要約キャッシュがすべて保存されない状態でした。TestFlight 配信版で発覚。

## 修正内容

- App / Extension の全 4 ターゲット (macOS / iOS) に \`com.apple.security.application-groups\` entitlement を追加
- App Group identifier: \`group.jp.co.orangesoft.dualview-translator\`
- 各 \`*.entitlements\` ファイルを Xcode 自動生成し \`CODE_SIGN_ENTITLEMENTS\` で参照
- Build Settings に \`REGISTER_APP_GROUPS = YES\` も追加

## Apple Developer Portal の事前作業

- App Group ID \`group.jp.co.orangesoft.dualview-translator\` を Identifiers に登録済み

## 動作確認

- macOS Safari (Debug ビルド・正規署名) で API キー保存 → ポップアップ閉じ → 再度開いて値が残ることを確認
- Web Inspector の Console で \`browser.storage.local.set\` が成功することを確認

## TestFlight 再配信が必要

このマージ後、Archive → App Store Connect Upload → TestFlight 再配信が必要です。マージは人間判断でお願いします。

closes #81