### PR TITLE
docs: Safari の App Store 申請完了マイルストーンをリリースノートに追記

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ permalink: /RELEASE_NOTES.html
 ### マイルストーン
 
 - **Safari (macOS / iOS) を Mac App Store / iOS App Store に申請**（2026-04-25）
-  - Issue #1 の Phase 4 完了。Apple 審査結果待ち（通常 24〜48 時間）
+  - Phase 4 完了（#1）。Apple 審査結果待ち（通常 24〜48 時間）
   - 申請ビルド: Safari Build 2 (Marketing Version 1.0)
   - 関連 PR: #74（HD アイコン）/ #76（提出設定）/ #82（App Group 修正）/ #84（Build 番号）
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,6 +7,13 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+### マイルストーン
+
+- **Safari (macOS / iOS) を Mac App Store / iOS App Store に申請**（2026-04-25）
+  - Issue #1 の Phase 4 完了。Apple 審査結果待ち（通常 24〜48 時間）
+  - 申請ビルド: Safari Build 2 (Marketing Version 1.0)
+  - 関連 PR: #74（HD アイコン）/ #76（提出設定）/ #82（App Group 修正）/ #84（Build 番号）
+
 ### バグ修正
 
 - **macOS Safari で API キーや設定が保存されない問題を修正**（#81）


### PR DESCRIPTION
## Summary

Issue #1 (Safari 対応) の Phase 4 として、2026-04-25 に Mac App Store / iOS App Store への申請が完了したことをリリースノートに記録。

## 変更内容

- \`docs/RELEASE_NOTES.md\` の「未リリース」セクション冒頭に「マイルストーン」サブセクションを新設し、Safari 申請の事実を追記
  - 申請ビルド: Safari Build 2 (Marketing Version 1.0)
  - 関連 PR: #74 / #76 / #82 / #84

## 補足

リリースノート本体（バージョン番号確定）は Apple 審査通過後に行う想定（Approved 後に Safari 1.0 として確定）。

closes #85