### PR TITLE
feat: manifest.json の description / commands を _locales で i18n 化

### DIFF
--- a/.claude/skills/build-zip.md
+++ b/.claude/skills/build-zip.md
@@ -47,6 +47,7 @@ Chrome Web Store / Firefox Add-ons への提出用。
 - `popup-init.js`
 - `popup.js`
 - `icons/`
+- `_locales/`
 - `LICENSE`
 
 ```bash
@@ -63,6 +64,7 @@ zip -r dualview-translator-<VERSION>.zip \
   popup-init.js \
   popup.js \
   icons/ \
+  _locales/ \
   LICENSE
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ LLM（Claude / Gemini）による要約機能も搭載。
 ├── popup-init.js          # ポップアップ初期化（テーマ適用・ショートカット表示）
 ├── popup.js               # ポップアップのイベント処理・タブ切り替え
 ├── icons/                 # 拡張アイコン（16/32/48/128px）
+├── _locales/              # ブラウザ標準 i18n（manifest description / commands）
+│   └── <lang>/messages.json #   11言語分（ar/de/en/es/fr/ja/ko/pt_BR/ru/zh_CN/zh_TW）
 ├── LICENSE                # MIT License
 ├── README.md              # ユーザー向けドキュメント
 ├── package.json           # npm設定（テスト用）
@@ -36,11 +38,12 @@ LLM（Claude / Gemini）による要約機能も搭載。
 │   ├── background.test.js  #  background テスト（18件）
 │   ├── safari-compat.test.js # Safari/iOS互換テスト（8件）
 │   ├── auto-rule-edit.test.js # 自動翻訳ルール編集テスト（10件）
-│   └── translation-cache.test.js # 翻訳・要約キャッシュテスト（31件）
+│   ├── translation-cache.test.js # 翻訳・要約キャッシュテスト（31件）
+│   └── locales.test.js    #   _locales 整合性テスト（7件）
 ├── docs/                  # 公開資料
 │   ├── chrome-web-store.md #   Chrome Web Store掲載用テキスト
 │   ├── RELEASE_NOTES.md   #   リリースノート
-│   ├── test-plan.md       #   テストプラン（74項目、Markdown表形式）
+│   ├── test-plan.md       #   テストプラン（79項目、Markdown表形式）
 │   └── manual-test-scenarios.yaml #  手動テストシナリオ（YAML、自動テスト補完）
 ├── safari/                # Safari Web Extension（Xcode プロジェクト）
 │   ├── README.md          #   ビルド・インストール手順
@@ -142,6 +145,11 @@ content-*.js → chrome.runtime.sendMessage → background.js → Google Transla
 - popup.htmlは `data-i18n` / `data-i18n-html` / `data-i18n-placeholder` 属性で自動翻訳
 - 新規メッセージ追加時は `i18n.js` の全11言語ブロックに追加すること
 - background.jsのコンテキストメニュータイトルは `CONTEXT_MENU_TITLES` に別途定義
+- ストア掲載文・ショートカット説明（`manifest.json` の `description` / `commands.*.description`）は
+  ブラウザ標準の `_locales/<lang>/messages.json` で管理し `__MSG_<key>__` で参照する
+  - 言語ディレクトリ命名は Chrome の locale 命名規則（`zh_CN` / `pt_BR` 等）
+  - `default_locale` は `en`（未対応 locale はここにフォールバック）
+  - `_locales/` の整合性は `tests/locales.test.js` で検証
 
 ## テーマ対応
 

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "إضافة ترجمة للمتصفح تعرض النص الأصلي والترجمة جنبًا إلى جنب. تدعم ترجمة التحديد وترجمة الصفحة بأكملها.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "تبديل ترجمة الصفحة بأكملها",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "ترجمة النص المحدد",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "الدخول إلى وضع تحديد المنطقة",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "Browser-Übersetzungserweiterung, die Original und Übersetzung nebeneinander anzeigt. Unterstützt Auswahl- und Ganzseitenübersetzung.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "Ganzseitenübersetzung umschalten",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "Ausgewählten Text übersetzen",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "Bereichsauswahlmodus aktivieren",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "Browser translation extension that shows the original and translation side by side. Supports text selection and full-page translation.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "Toggle full-page translation",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "Translate selected text",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "Enter region selection mode",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "Extensión de traducción del navegador que muestra el original y la traducción en paralelo. Admite traducción de selección y de página completa.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "Alternar la traducción de la página",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "Traducir el texto seleccionado",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "Entrar en el modo de selección de región",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "Extension de traduction qui affiche l'original et la traduction côte à côte. Prend en charge la traduction de la sélection et de la page entière.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "Activer/désactiver la traduction de la page",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "Traduire le texte sélectionné",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "Activer le mode de sélection de zone",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "原文と翻訳を並べて表示するブラウザ翻訳拡張。選択翻訳・ページ全体翻訳に対応。",
+    "description": "Chrome Web Store / Firefox Add-ons の掲載やブラウザの拡張一覧に表示される説明文。"
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "ページ全体翻訳のトグル",
+    "description": "ページ全体翻訳をトグルするキーボードショートカットの説明。"
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "選択テキストを翻訳",
+    "description": "選択中のテキストを翻訳するキーボードショートカットの説明。"
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "領域選択モードを開始",
+    "description": "領域（要素）選択モードに入るキーボードショートカットの説明。"
+  }
+}

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "원문과 번역을 나란히 보여주는 브라우저 번역 확장. 선택 번역과 전체 페이지 번역을 지원합니다.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "전체 페이지 번역 전환",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "선택한 텍스트 번역",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "영역 선택 모드 진입",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "Extensão de tradução para navegador que exibe o original e a tradução lado a lado. Suporta tradução de seleção e de página inteira.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "Alternar tradução da página",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "Traduzir o texto selecionado",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "Entrar no modo de seleção de região",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "Расширение браузера для перевода, отображающее оригинал и перевод рядом. Поддерживает перевод выделенного текста и всей страницы.",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "Переключить перевод страницы",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "Перевести выделенный текст",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "Войти в режим выбора области",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "并排显示原文和译文的浏览器翻译扩展。支持划词翻译和整页翻译。",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "切换整页翻译",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "翻译选定的文本",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "进入区域选择模式",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,0 +1,18 @@
+{
+  "extDescription": {
+    "message": "並排顯示原文和譯文的瀏覽器翻譯擴充功能。支援選取翻譯和整頁翻譯。",
+    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+  },
+  "cmdTogglePageTranslateDescription": {
+    "message": "切換整頁翻譯",
+    "description": "Description for the keyboard shortcut that toggles full-page translation."
+  },
+  "cmdTranslateSelectionDescription": {
+    "message": "翻譯選取的文字",
+    "description": "Description for the keyboard shortcut that translates the currently selected text."
+  },
+  "cmdEnterRegionModeDescription": {
+    "message": "進入區域選取模式",
+    "description": "Description for the keyboard shortcut that enters the region (element) selection mode."
+  }
+}

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -9,6 +9,16 @@ permalink: /RELEASE_NOTES.en.html
 
 ## Unreleased
 
+### Improvements
+
+- **Localized store description & shortcut hints via the browser's built-in i18n (`_locales/`)** (#93)
+  - Replaced `manifest.json`'s `description` and `commands.*.description` with `__MSG_<key>__` placeholders
+    and shipped 11 language packs (ar / de / en / es / fr / ja / ko / pt_BR / ru / zh_CN / zh_TW) under `_locales/`
+  - Now the description in Chrome Web Store / Firefox Add-ons / Mac App Store / iOS App Store listings
+    and the shortcut hints in `chrome://extensions/shortcuts` show up in the user's browser language
+  - `default_locale` is `en` — anything we haven't translated falls back here
+  - The Safari Web Extension Xcode project also picks up `_locales/` as a build resource
+
 ### Documentation
 
 - **English versions of extension descriptions** (#91)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -9,6 +9,16 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+### 改善
+
+- **ストア掲載文・ショートカット説明をブラウザ標準 i18n（`_locales/`）で多言語化**（#93）
+  - `manifest.json` の `description` と `commands.*.description` を `__MSG_<key>__` 化し
+    `_locales/<lang>/messages.json` に 11 言語分（ar / de / en / es / fr / ja / ko / pt_BR / ru / zh_CN / zh_TW）の翻訳を追加
+  - これにより Chrome Web Store / Firefox Add-ons / Mac App Store / iOS App Store の拡張一覧説明文と
+    `chrome://extensions/shortcuts` のショートカット説明がユーザーのブラウザ言語で表示される
+  - `default_locale` は `en`（未対応 locale はここにフォールバック）
+  - Safari Web Extension の Xcode プロジェクトにも `_locales/` をビルドリソースとして追加
+
 ### ドキュメント
 
 - **拡張機能の説明文に英語版を追加**（#91）

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -852,3 +852,81 @@ suites:
         expected:
           - 「未対応のPRはありません」と表示して終了する
           - "デバッグログ上、オープンPR有無の確認（`gh pr list`）のみで終了し、PR詳細取得・インラインコメント取得などの追加 API 呼び出しが発生しない"
+
+  # ━━━━━ 14. manifest.json の i18n 化（_locales） ━━━━━
+  - id: manifest-i18n
+    title: "manifest.json の description / commands ローカライズ"
+    description: "PR #93 で `_locales/<lang>/messages.json` + `default_locale` 方式に切替えた挙動の確認"
+    related_prs: [93]
+    scenarios:
+
+      - id: MI-001
+        title: "ブラウザ言語=日本語で description / commands が日本語表示される"
+        priority: p1
+        environment: chrome
+        preconditions:
+          - "Chrome の言語設定で日本語を最優先にして再起動済み"
+          - "拡張をデベロッパーモードでインストール済み（または Web Store 公開版）"
+        steps:
+          - "`chrome://extensions/` を開く"
+          - "DualView Translator のカードを確認"
+          - "`chrome://extensions/shortcuts` を開いて DualView Translator のセクションを確認"
+        expected:
+          - "拡張一覧の説明文が `原文と翻訳を並べて表示するブラウザ翻訳拡張...` と日本語で表示される"
+          - "`shortcuts` ページの 3 ショートカット説明が `ページ全体翻訳のトグル` / `選択テキストを翻訳` / `領域選択モードを開始` と日本語表示される"
+
+      - id: MI-002
+        title: "ブラウザ言語=英語で英語表示される"
+        priority: p1
+        environment: chrome
+        preconditions:
+          - "Chrome の言語設定で English を最優先にして再起動済み"
+        steps:
+          - "`chrome://extensions/` および `chrome://extensions/shortcuts` を確認"
+        expected:
+          - "description が `Browser translation extension that shows the original and translation side by side. ...` と英語表示"
+          - "ショートカット説明が `Toggle full-page translation` / `Translate selected text` / `Enter region selection mode` と英語表示"
+
+      - id: MI-003
+        title: "未対応 locale で default_locale (en) にフォールバック"
+        priority: p2
+        environment: chrome
+        preconditions:
+          - "Chrome の言語設定を `_locales/` に存在しない言語（例: hi / th / vi）にして再起動"
+        steps:
+          - "`chrome://extensions/` を確認"
+        expected:
+          - "description が英語で表示される（`default_locale: en` のフォールバックが効く）"
+
+      - id: MI-004
+        title: "Firefox の about:addons 上で description が表示言語に追従する"
+        priority: p1
+        environment: firefox
+        preconditions:
+          - "Firefox の言語パックを切替えて再起動（例: 日本語版）"
+        steps:
+          - "`about:addons` の拡張機能タブで DualView Translator のカードをクリック"
+        expected:
+          - "詳細パネルの説明文が選択中の Firefox 言語で表示される"
+
+      - id: MI-005
+        title: "Safari (macOS) の機能拡張ペインで description が表示される"
+        priority: p2
+        environment: safari-mac
+        preconditions:
+          - "macOS のシステム言語を切替えて再ログイン（または再起動）"
+          - "Safari Web Extension を有効化済み"
+        steps:
+          - "Safari → 設定 → 拡張機能 → DualView Translator を選択"
+        expected:
+          - "右ペインの説明文が macOS のシステム言語に対応した翻訳で表示される（未対応なら英語フォールバック）"
+
+      - id: MI-006
+        title: "拡張ビルドの `_locales/` がパッケージに含まれている"
+        priority: p0
+        steps:
+          - "`/skill build-zip` または `npm run` 経由でリリース zip を作成"
+          - "`unzip -l dualview-translator-<VERSION>.zip` を実行"
+        expected:
+          - "`_locales/<lang>/messages.json` が 11 言語分（ar / de / en / es / fr / ja / ko / pt_BR / ru / zh_CN / zh_TW）すべて含まれる"
+          - "`manifest.json` 内の `description` および `commands.*.description` が `__MSG_*__` 形式になっている"

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -207,4 +207,16 @@
 
 ---
 
+## 13. ストア掲載文・ショートカット説明（`_locales/`）
+
+| # | テスト項目 | 手順 | 期待結果 |
+|---|----------|------|---------|
+| 75 | 説明文の言語追従（Chrome / 日本語） | ブラウザ言語を日本語にして `chrome://extensions/` を開く | 拡張一覧の説明文が日本語版で表示される |
+| 76 | 説明文の言語追従（Chrome / 英語） | ブラウザ言語を英語にして `chrome://extensions/` を開く | 説明文が英語版で表示される |
+| 77 | ショートカット説明の言語追従 | ブラウザ言語を日本語にして `chrome://extensions/shortcuts` を開く | 3 ショートカットの説明が日本語表示 |
+| 78 | 未対応 locale のフォールバック | ブラウザ言語を未対応の言語（hi 等）にして拡張一覧を開く | `default_locale: en` に従って英語で表示される |
+| 79 | パッケージに `_locales/` が含まれる | `unzip -l dualview-translator-<VERSION>.zip` で確認 | 11 言語分の `messages.json` が梱包されている |
+
+---
+
 Copyright (c) Orangesoft Inc

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,8 @@
   "manifest_version": 3,
   "name": "DualView Translator",
   "version": "1.3.0",
-  "description": "原文と翻訳を並べて表示するブラウザ翻訳拡張。選択翻訳・ページ全体翻訳に対応。",
+  "default_locale": "en",
+  "description": "__MSG_extDescription__",
   "permissions": [
     "activeTab",
     "storage",
@@ -66,21 +67,21 @@
         "default": "Ctrl+Shift+T",
         "mac": "Command+Shift+T"
       },
-      "description": "Toggle page translation / ページ全体翻訳のトグル"
+      "description": "__MSG_cmdTogglePageTranslateDescription__"
     },
     "translate-selection": {
       "suggested_key": {
         "default": "Ctrl+Shift+Y",
         "mac": "Command+Shift+Y"
       },
-      "description": "Translate selected text / 選択テキストを翻訳"
+      "description": "__MSG_cmdTranslateSelectionDescription__"
     },
     "enter-region-mode": {
       "suggested_key": {
         "default": "Ctrl+Shift+R",
         "mac": "Command+Shift+R"
       },
-      "description": "Enter region selection mode / 領域選択モード"
+      "description": "__MSG_cmdEnterRegionModeDescription__"
     }
   },
   "icons": {

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		7D1D48622F95AD9600B65F5F /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 7D1D48322F95AD9500B65F5F /* manifest.json */; };
 		7D1D48642F95AD9600B65F5F /* i18n.js in Resources */ = {isa = PBXBuildFile; fileRef = 7D1D48342F95AD9500B65F5F /* i18n.js */; };
 		7D1D48652F95AD9600B65F5F /* popup-init.js in Resources */ = {isa = PBXBuildFile; fileRef = 7D1D48352F95AD9500B65F5F /* popup-init.js */; };
+		7DA0CA1F2F95AD9500B65F5F /* _locales in Resources */ = {isa = PBXBuildFile; fileRef = 7DA0CA1E2F95AD9500B65F5F /* _locales */; };
+		7DA0CA202F95AD9500B65F5F /* _locales in Resources */ = {isa = PBXBuildFile; fileRef = 7DA0CA1E2F95AD9500B65F5F /* _locales */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +137,7 @@
 		7D1D48322F95AD9500B65F5F /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = manifest.json; path = ../../../manifest.json; sourceTree = "<group>"; };
 		7D1D48342F95AD9500B65F5F /* i18n.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = i18n.js; path = ../../../i18n.js; sourceTree = "<group>"; };
 		7D1D48352F95AD9500B65F5F /* popup-init.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "popup-init.js"; path = "../../../popup-init.js"; sourceTree = "<group>"; };
+		7DA0CA1E2F95AD9500B65F5F /* _locales */ = {isa = PBXFileReference; lastKnownFileType = folder; name = _locales; path = ../../../_locales; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -276,6 +279,7 @@
 				7D1D48252F95AD9500B65F5F /* background.js */,
 				7D1D48262F95AD9500B65F5F /* popup.html */,
 				7D1D48302F95AD9500B65F5F /* icons */,
+				7DA0CA1E2F95AD9500B65F5F /* _locales */,
 				7D1D48312F95AD9500B65F5F /* content-bar.js */,
 				7D1D48322F95AD9500B65F5F /* manifest.json */,
 				7D1D48342F95AD9500B65F5F /* i18n.js */,
@@ -449,6 +453,7 @@
 				7D1D48652F95AD9600B65F5F /* popup-init.js in Resources */,
 				7D1D48562F95AD9500B65F5F /* popup.html in Resources */,
 				7D1D48602F95AD9600B65F5F /* icons in Resources */,
+				7DA0CA1F2F95AD9500B65F5F /* _locales in Resources */,
 				7D1D484F2F95AD9500B65F5F /* content-page.js in Resources */,
 				7D1D48552F95AD9500B65F5F /* background.js in Resources */,
 				7D1D48642F95AD9600B65F5F /* i18n.js in Resources */,
@@ -468,6 +473,7 @@
 				7D1D484D2F95AD9500B65F5F /* popup-init.js in Resources */,
 				7D1D483E2F95AD9500B65F5F /* popup.html in Resources */,
 				7D1D48482F95AD9500B65F5F /* icons in Resources */,
+				7DA0CA202F95AD9500B65F5F /* _locales in Resources */,
 				7D1D48372F95AD9500B65F5F /* content-page.js in Resources */,
 				7D1D483D2F95AD9500B65F5F /* background.js in Resources */,
 				7D1D484C2F95AD9500B65F5F /* i18n.js in Resources */,

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -1,0 +1,116 @@
+// Copyright (c) Orangesoft Inc.
+// _locales/<lang>/messages.json と manifest.json の整合性を検証する
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ROOT = resolve(__dirname, '..');
+const LOCALES_DIR = join(ROOT, '_locales');
+const MANIFEST_PATH = join(ROOT, 'manifest.json');
+
+// _locales 配下の全言語ディレクトリを列挙
+function listLocales() {
+  return readdirSync(LOCALES_DIR)
+    .filter((name) => statSync(join(LOCALES_DIR, name)).isDirectory())
+    .sort();
+}
+
+function loadMessages(locale) {
+  const path = join(LOCALES_DIR, locale, 'messages.json');
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function loadManifest() {
+  return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+// manifest.json から __MSG_<key>__ を抽出
+function extractMsgKeys(obj, acc = new Set()) {
+  if (typeof obj === 'string') {
+    const m = obj.match(/^__MSG_(\w+)__$/);
+    if (m) acc.add(m[1]);
+  } else if (Array.isArray(obj)) {
+    for (const v of obj) extractMsgKeys(v, acc);
+  } else if (obj && typeof obj === 'object') {
+    for (const v of Object.values(obj)) extractMsgKeys(v, acc);
+  }
+  return acc;
+}
+
+describe('_locales — 拡張機能の i18n 化', () => {
+  const locales = listLocales();
+
+  // 期待する言語リスト（i18n.js の DVT_I18N と対応するが、Chrome locale 命名規則に従う）
+  const EXPECTED_LOCALES = [
+    'ar',
+    'de',
+    'en',
+    'es',
+    'fr',
+    'ja',
+    'ko',
+    'pt_BR',
+    'ru',
+    'zh_CN',
+    'zh_TW',
+  ];
+
+  it('11 言語分のディレクトリが揃っている', () => {
+    expect(locales).toEqual(EXPECTED_LOCALES);
+  });
+
+  it('manifest.json の default_locale は _locales 配下に存在する', () => {
+    const manifest = loadManifest();
+    expect(manifest.default_locale).toBeDefined();
+    expect(locales).toContain(manifest.default_locale);
+  });
+
+  it('manifest.json で参照される全 __MSG_*__ キーが default_locale に存在する', () => {
+    const manifest = loadManifest();
+    const referenced = [...extractMsgKeys(manifest)];
+    expect(referenced.length).toBeGreaterThan(0);
+
+    const defaultMessages = loadMessages(manifest.default_locale);
+    for (const key of referenced) {
+      expect(defaultMessages[key], `default locale に ${key} が無い`).toBeDefined();
+      expect(defaultMessages[key].message).toBeTruthy();
+    }
+  });
+
+  it('全 locale が default_locale と同じキーセットを持つ', () => {
+    const manifest = loadManifest();
+    const baseKeys = Object.keys(loadMessages(manifest.default_locale)).sort();
+    expect(baseKeys.length).toBeGreaterThan(0);
+
+    for (const locale of locales) {
+      const keys = Object.keys(loadMessages(locale)).sort();
+      expect(keys, `${locale} のキーセットが ${manifest.default_locale} と一致しない`).toEqual(baseKeys);
+    }
+  });
+
+  it('全 locale の全エントリに非空の message プロパティがある', () => {
+    for (const locale of locales) {
+      const messages = loadMessages(locale);
+      for (const [key, value] of Object.entries(messages)) {
+        expect(value, `${locale}.${key} がオブジェクトでない`).toBeTypeOf('object');
+        expect(value.message, `${locale}.${key}.message が空`).toBeTruthy();
+        expect(typeof value.message, `${locale}.${key}.message が文字列でない`).toBe('string');
+      }
+    }
+  });
+
+  it('manifest.json の name と action.default_title はブランド名のまま (__MSG_*__ 化しない)', () => {
+    const manifest = loadManifest();
+    expect(manifest.name).toBe('DualView Translator');
+    expect(manifest.action.default_title).toBe('DualView Translator');
+  });
+
+  it('manifest.json の commands.*.description は全て __MSG_*__ 化されている', () => {
+    const manifest = loadManifest();
+    for (const [name, def] of Object.entries(manifest.commands)) {
+      expect(def.description, `commands.${name}.description が __MSG_*__ 形式でない`)
+        .toMatch(/^__MSG_\w+__$/);
+    }
+  });
+});

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 
-const ROOT = resolve(__dirname, '..');
+const ROOT = resolve(import.meta.dirname, '..');
 const LOCALES_DIR = join(ROOT, '_locales');
 const MANIFEST_PATH = join(ROOT, 'manifest.json');
 
@@ -93,9 +93,13 @@ describe('_locales — 拡張機能の i18n 化', () => {
     for (const locale of locales) {
       const messages = loadMessages(locale);
       for (const [key, value] of Object.entries(messages)) {
+        // toBeTypeOf('object') は null も通すため、null でないことを明示的に検証する
+        expect(value, `${locale}.${key} が null`).not.toBeNull();
         expect(value, `${locale}.${key} がオブジェクトでない`).toBeTypeOf('object');
-        expect(value.message, `${locale}.${key}.message が空`).toBeTruthy();
-        expect(typeof value.message, `${locale}.${key}.message が文字列でない`).toBe('string');
+        // toBeTruthy() だと空白のみの文字列も通ってしまうため、文字列として trim 後の長さで検証する
+        const message = value.message;
+        expect(typeof message, `${locale}.${key}.message が文字列でない`).toBe('string');
+        expect(message.trim().length, `${locale}.${key}.message が空または空白のみ`).toBeGreaterThan(0);
       }
     }
   });


### PR DESCRIPTION
## Summary

- `manifest.json` の `description` と `commands.*.description` を `__MSG_<key>__` 化
- `_locales/<lang>/messages.json` を **11 言語分**（ar / de / en / es / fr / ja / ko / pt_BR / ru / zh_CN / zh_TW）追加
- `default_locale: "en"` を設定（未対応 locale はここにフォールバック）
- Safari Web Extension の Xcode プロジェクト（pbxproj）にも `_locales/` をビルドリソースとして追加（macOS / iOS 両 extension target）
- 自動テスト `tests/locales.test.js` で次を検証
  - 11 言語ディレクトリが揃っている
  - `manifest.json` が参照する全 `__MSG_*__` キーが `default_locale` に存在
  - 全 locale で同一キーセット
  - 全エントリの `message` が非空
  - `name` / `action.default_title` はブランド名のまま（非ローカライズ）
  - `commands.*.description` は全て `__MSG_*__` 形式

## 変更による効果

- Chrome Web Store / Firefox Add-ons / Mac App Store / iOS App Store の拡張一覧で
  説明文がユーザーのブラウザ言語で表示される
- `chrome://extensions/shortcuts` のショートカット説明もユーザー言語で表示
- これまで日本語 + 英語の併記文字列だった `commands.*.description` が解消

## 範囲外（後続検討）

- popup や content の UI 文字列は引き続き `i18n.js` の `DVT_I18N`（ストレージ設定でユーザーが UI 言語を選択する仕組み）を利用
- ブランド名（`name` / `action.default_title`）は固定のまま

## Test plan

- [x] `npm test` — 357 件全件パス（うち locales 整合性 7 件）
- [x] `xcodebuild` で macOS Safari extension の `BUILD SUCCEEDED` を確認、
      `_locales/<lang>/messages.json` が `.appex/Contents/Resources/_locales/` に 11 言語分コピーされていることを確認
- [ ] 手動テスト（`docs/manual-test-scenarios.yaml` の suite `manifest-i18n` MI-001〜MI-006）
  - [ ] Chrome 言語=日本語で `chrome://extensions/` の説明文が日本語表示
  - [ ] Chrome 言語=英語で説明文が英語表示
  - [ ] 未対応 locale で `default_locale: en` にフォールバック
  - [ ] Firefox `about:addons` で description が言語追従
  - [ ] Safari (macOS) 機能拡張ペインで description 表示
  - [ ] リリース zip に `_locales/` が含まれている

closes #93