### PR TITLE
docs: GitHub Pages の Firefox AMO リンク追加とリリースノートリンク整理

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -24,6 +24,11 @@ permalink: /RELEASE_NOTES.en.html
 - **English versions of extension descriptions** (#91)
   - Added `docs/chrome-web-store.en.md` / `docs/firefox-add-ons.en.md` / `README.en.md`
   - Targets English-speaking users and overseas distribution on Chrome Web Store / Firefox AMO
+- **Linked the published Firefox Add-ons page from the GitHub Pages landing pages** (#94)
+  - The "Distribution" section in `docs/index.md` / `docs/index.en.md` now points to the AMO page instead of saying "coming soon"
+- **Cleaned up release-notes links on the GitHub Pages landing pages so each language only shows its own** (#95)
+  - Dropped the cross-language release-notes link from `docs/index.md` / `docs/index.en.md`
+  - You can still hop between languages from the language toggle at the top of each release-notes page
 
 ### Milestones
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -25,6 +25,11 @@ permalink: /RELEASE_NOTES.html
   - `docs/chrome-web-store.en.md` / `docs/firefox-add-ons.en.md` / `README.en.md` / `docs/RELEASE_NOTES.en.md` を新規追加
   - 既存の日本語版とは別に、英語圏ユーザー / Chrome Web Store / Firefox AMO 海外配信向けの説明文を整備
   - `.claude/CLAUDE.md` に「日英両方のドキュメントを必ず更新する」ルールを明記
+- **GitHub Pages のトップページに Firefox Add-ons の公開リンクを掲載**（#94）
+  - `docs/index.md` / `docs/index.en.md` の「配布」セクションで、Firefox を「準備中」表記から AMO ページへのリンクに更新
+- **GitHub Pages のリリースノートリンクを自言語版に統一**（#95）
+  - `docs/index.md` / `docs/index.en.md` から他言語版リリースノートへのリンクを削除し、自言語版のみ表示
+  - 他言語版へはリリースノート冒頭の言語切り替えリンクから遷移できる
 
 ### マイルストーン
 

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -14,8 +14,7 @@ A browser extension that shows the translation **right below the original** in a
 ## Documentation
 
 - [Privacy Policy](privacy-policy.html)
-- [Release Notes (English)](RELEASE_NOTES.en.html)
-- [リリースノート (Japanese)](RELEASE_NOTES.html)
+- [Release Notes](RELEASE_NOTES.en.html)
 
 ## Repository
 
@@ -25,5 +24,5 @@ Source code is on GitHub:
 ## Distribution
 
 - Chrome: Chrome Web Store (coming soon)
-- Firefox: Firefox Add-ons (coming soon)
+- Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/dualview-translator/)
 - macOS / iOS Safari: Mac App Store / iOS App Store (coming soon)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,7 @@ Copyright (c) Orangesoft Inc.
 ## ドキュメント
 
 - [Privacy Policy](privacy-policy.html)（英語）
-- [リリースノート（日本語）](RELEASE_NOTES.html)
-- [Release Notes (English)](RELEASE_NOTES.en.html)
+- [リリースノート](RELEASE_NOTES.html)
 
 ## リポジトリ
 
@@ -25,5 +24,5 @@ Copyright (c) Orangesoft Inc.
 ## 配布
 
 - Chrome: Chrome Web Store（準備中）
-- Firefox: Firefox Add-ons（準備中）
+- Firefox: [Firefox Add-ons](https://addons.mozilla.org/ja/firefox/addon/dualview-translator/)
 - macOS / iOS Safari: Mac App Store / iOS App Store（準備中）


### PR DESCRIPTION
## Summary

GitHub Pages のトップページ（`docs/index.md` / `docs/index.en.md`）に対する 2 件のドキュメント修正をまとめて対応。

- **#94**: 「配布」セクションの Firefox を「準備中」表記から AMO 公開ページへのリンクに更新
  - 日本語版: `https://addons.mozilla.org/ja/firefox/addon/dualview-translator/`
  - 英語版: `https://addons.mozilla.org/en-US/firefox/addon/dualview-translator/`
- **#95**: 「ドキュメント」セクションのリリースノートを自言語版のみ 1 行で表示するよう整理
  - これまで日本語版／英語版の両方に他言語版へのリンクが並んでおり、各ページで英日が混在していた
  - リリースノートページ冒頭には言語切り替えリンク（`日本語 | English`）が既にあるため、そちらから他言語版に遷移可能

`docs/RELEASE_NOTES.md` / `RELEASE_NOTES.en.md` の「未リリース／ドキュメント」セクションにも上記 2 件を追記。

## Test plan

- [x] GitHub Pages のドキュメント変更のみ（`docs/*.md`）。挙動を変更するコードは含まれない
  - 既存の自動テスト 357 件は全てパス（`npm test`）
- [ ] マージ後に Pages がビルドされた後、ライブで以下を確認:
  - [ ] 日本語版トップ `https://hirokatsuhibino.github.io/dualview-translator/` の「配布」セクションで Firefox が AMO リンクに変わっている
  - [ ] 英語版トップ `https://hirokatsuhibino.github.io/dualview-translator/index.en.html` でも同様
  - [ ] 「ドキュメント」セクションのリリースノートが自言語版 1 リンクのみになっている

> テストプラン / 自動テスト / 手動テストシナリオの追加・更新はスキップ。
> 根拠: 変更対象は GitHub Pages の Markdown のみで、拡張本体・拡張機能の挙動・ビルド設定には影響しない。

closes #94
closes #95