### PR TITLE
docs: GitHub Pages のトップページに開発元（オレンジソフト）情報を追加

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -29,6 +29,8 @@ permalink: /RELEASE_NOTES.en.html
 - **Cleaned up release-notes links on the GitHub Pages landing pages so each language only shows its own** (#95)
   - Dropped the cross-language release-notes link from `docs/index.md` / `docs/index.en.md`
   - You can still hop between languages from the language toggle at the top of each release-notes page
+- **Added a "Developer" section to the GitHub Pages landing pages** (#98)
+  - New "Developer" section on `docs/index.md` / `docs/index.en.md` linking to Orangesoft Inc. and our other products (safeAttach / xgate4)
 
 ### Milestones
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -30,6 +30,9 @@ permalink: /RELEASE_NOTES.html
 - **GitHub Pages のリリースノートリンクを自言語版に統一**（#95）
   - `docs/index.md` / `docs/index.en.md` から他言語版リリースノートへのリンクを削除し、自言語版のみ表示
   - 他言語版へはリリースノート冒頭の言語切り替えリンクから遷移できる
+- **GitHub Pages のトップページに開発元（オレンジソフト）情報を追加**（#98）
+  - `docs/index.md` / `docs/index.en.md` に「開発元 / Developer」セクションを新規追加
+  - 開発元（株式会社オレンジソフト）と関連製品（safeAttach / xgate4）へのリンクを掲載
 
 ### マイルストーン
 

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -26,3 +26,7 @@ Source code is on GitHub:
 - Chrome: Chrome Web Store (coming soon)
 - Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/dualview-translator/)
 - macOS / iOS Safari: Mac App Store / iOS App Store (coming soon)
+
+## Developer
+
+DualView Translator is developed by [Orangesoft Inc.](https://www.orangesoft.co.jp/) — also makers of [safeAttach](https://www.orangesoft.co.jp/safeattach) and [xgate4](https://www.orangesoft.co.jp/xgate).

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,3 +26,8 @@ Copyright (c) Orangesoft Inc.
 - Chrome: Chrome Web Store（準備中）
 - Firefox: [Firefox Add-ons](https://addons.mozilla.org/ja/firefox/addon/dualview-translator/)
 - macOS / iOS Safari: Mac App Store / iOS App Store（準備中）
+
+## 開発元
+
+DualView Translator は[株式会社オレンジソフト](https://www.orangesoft.co.jp/)が開発しています。
+他にも [safeAttach](https://www.orangesoft.co.jp/safeattach)、[xgate4](https://www.orangesoft.co.jp/xgate) などのソフトウェアを提供しています。


### PR DESCRIPTION
## Summary

GitHub Pages のトップページ（`docs/index.md` / `docs/index.en.md`）に「開発元」/「Developer」セクションを新規追加し、開発元（株式会社オレンジソフト）と関連製品（safeAttach / xgate4）へのリンクを掲載する。

#90 の設定画面側の自社製品紹介とは独立して、ストア審査リスクのない GitHub Pages 側を先行対応。

### 変更内容

- `docs/index.md` / `docs/index.en.md` の「配布」/「Distribution」セクション直後に新規セクションを追加
- リンク先:
  - 開発元: https://www.orangesoft.co.jp/
  - safeAttach: https://www.orangesoft.co.jp/safeattach
  - xgate4: https://www.orangesoft.co.jp/xgate
- `docs/RELEASE_NOTES.md` / `RELEASE_NOTES.en.md` の「未リリース／ドキュメント」セクションに追記

## Test plan

- [x] 既存自動テスト 357 件全件パス（`npm test`）
- [ ] マージ後、Pages がビルドされたら以下を確認:
  - [ ] 日本語版 `https://hirokatsuhibino.github.io/dualview-translator/` の末尾に「開発元」セクションが表示される
  - [ ] 英語版 `https://hirokatsuhibino.github.io/dualview-translator/index.en.html` の末尾に「Developer」セクションが表示される
  - [ ] 各リンクが新規タブ／同タブで正しく該当ページに遷移する

> テストプラン / 自動テスト / 手動テストシナリオの追加・更新はスキップ。
> 根拠: 変更対象は GitHub Pages の Markdown のみで、拡張本体・拡張機能の挙動には影響しない。

closes #98