### PR TITLE
docs: RELEASE_NOTES.en.md の表現を中立トーンに統一

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -30,7 +30,7 @@ permalink: /RELEASE_NOTES.en.html
   - Dropped the cross-language release-notes link from `docs/index.md` / `docs/index.en.md`
   - You can still hop between languages from the language toggle at the top of each release-notes page
 - **Added a "Developer" section to the GitHub Pages landing pages** (#98)
-  - New "Developer" section on `docs/index.md` / `docs/index.en.md` linking to Orangesoft Inc. and our other products (safeAttach / xgate4)
+  - New "Developer" section on `docs/index.md` / `docs/index.en.md` linking to Orangesoft Inc. and other products (safeAttach / xgate4)
 
 ### Milestones
 


### PR DESCRIPTION
## Summary

PR #99 のレビュー指摘（Copilot）の follow-up。`docs/RELEASE_NOTES.en.md` 33 行目の \`our other products\` を中立的な \`other products\` に変更し、ドキュメント全体のトーンと整合させる。

## Test plan

- [x] 既存自動テスト 357 件全件パス（\`npm test\`）

> テストプラン / 自動テスト / 手動テストシナリオの追加・更新はスキップ。
> 根拠: 文言修正のみで、拡張本体・ビルド・挙動には影響しない。

closes #100