### PR TITLE
fix: Claude PR Review Response workflow が issue_comment で失敗する問題を修正

### DIFF
--- a/.github/workflows/claude-pr-review-response.yml
+++ b/.github/workflows/claude-pr-review-response.yml
@@ -66,10 +66,12 @@ jobs:
           esac
 
           # PR の fork / draft 状態を取得（issue_comment は event から直接取れないので gh で補完）
+          # guard ジョブは軽量化のため actions/checkout を実行していないので、
+          # gh pr view には --repo を明示してリポジトリコンテキストを与える
           if [ "${IS_ISSUE_COMMENT}" = "true" ]; then
             PR_NUM="${{ github.event.issue.number }}"
-            IS_FORK=$(gh pr view "${PR_NUM}" --json headRepository --jq '.headRepository.isFork // false')
-            IS_DRAFT=$(gh pr view "${PR_NUM}" --json isDraft --jq '.isDraft')
+            IS_FORK=$(gh pr view "${PR_NUM}" --repo "${{ github.repository }}" --json headRepository --jq '.headRepository.isFork // false')
+            IS_DRAFT=$(gh pr view "${PR_NUM}" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')
           else
             IS_FORK="${{ github.event.pull_request.head.repo.fork }}"
             IS_DRAFT="${{ github.event.pull_request.draft }}"
@@ -115,7 +117,8 @@ jobs:
 
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             # issue_comment は event から head.ref が取れないため gh で補完
-            REF=$(gh pr view "${{ github.event.issue.number }}" --json headRefName --jq '.headRefName')
+            # checkout 前に実行するので --repo でリポジトリコンテキストを明示
+            REF=$(gh pr view "${{ github.event.issue.number }}" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
           else
             REF="${{ github.event.pull_request.head.ref }}"
           fi


### PR DESCRIPTION
## Summary

PR の会話欄にコメントを投稿するたびに \`Claude PR Review Response\` ワークフローが failure になっていた問題を修正。

### 失敗例

- [Run #24978032445](https://github.com/hirokatsuhibino/dualview-translator/actions/runs/24978032445)（PR #108 のサマリコメント時）
- [Run #24977393037](https://github.com/hirokatsuhibino/dualview-translator/actions/runs/24977393037)（PR #106 のサマリコメント時）

### 原因

guard ジョブが軽量化のため \`actions/checkout\` を実行していないため、\`gh pr view\` 実行時に git リポジトリコンテキストがなく以下のエラーで失敗:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

\`pull_request_review\` / \`pull_request_review_comment\` イベントでは event payload から fork / draft 情報が直接取れるため \`gh pr view\` を呼ばず影響なし。\`issue_comment\` イベントでのみ発火していた。

### 修正

3 箇所すべての \`gh pr view\` に \`--repo \"\${{ github.repository }}\"\` を追加してリポジトリコンテキストを明示。これで checkout なしでも動作する。

| 場所 | 役割 |
|---|---|
| guard ジョブ 71 行 | IS_FORK 取得 |
| guard ジョブ 72 行 | IS_DRAFT 取得 |
| respond ジョブ 118 行 | PR head ref 解決 |

## Test plan

- [x] ワークフローファイル変更のみで自動テスト・コードへの影響はない
- [ ] **マージ後**、次回の PR 会話コメント投稿で \`issue_comment\` トリガーの guard が success（または notice で skip）になることを確認

> テストプラン / 自動テスト / 手動テストシナリオの追加・更新はスキップ。
> 根拠: GitHub Actions ワークフローの修正のみで、拡張本体の挙動・ビルドには影響しない。

closes #109