### PR TITLE
fix: GitHub Pages の英語ページでサブタイトルが日本語のまま表示される問題を修正

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -1,5 +1,6 @@
 ---
 title: Release Notes
+description: Release notes for DualView Translator.
 permalink: /RELEASE_NOTES.en.html
 ---
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ---
 title: Release Notes
+description: DualView Translator のリリースノート。
 permalink: /RELEASE_NOTES.html
 ---
 

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,5 +1,6 @@
 ---
 title: DualView Translator
+description: A browser translation extension that shows the translation right below the original.
 permalink: /index.en.html
 ---
 <!--

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: DualView Translator
+description: 原文と翻訳を並べて表示するブラウザ翻訳拡張。
 permalink: /index.html
 ---
 <!--

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Privacy Policy
+description: Privacy policy for DualView Translator.
 permalink: /privacy-policy.html
 ---
 


### PR DESCRIPTION
## Summary

GitHub Pages の英語ページ（\`index.en.html\` / \`RELEASE_NOTES.en.html\` / \`privacy-policy.html\`）の cayman テーマヘッダー \`project-tagline\` および \`<meta name=\"description\">\` / \`og:description\` が、日本語の「原文と翻訳を並べて表示するブラウザ翻訳拡張」のままになっていた問題を修正。

### 原因

\`_config.yml\` の \`description\` が日本語固定で、各ページにフロントマター \`description\` が無いためフォールバックされていた。

### 修正

各 Markdown ページのフロントマターに言語に合わせた \`description\` を追加（cayman テーマは \`{{ page.description | default: site.description }}\` で参照）:

| ファイル | 言語 |
|---|---|
| \`docs/index.md\` | 日本語 |
| \`docs/index.en.md\` | 英語 |
| \`docs/RELEASE_NOTES.md\` | 日本語 |
| \`docs/RELEASE_NOTES.en.md\` | 英語 |
| \`docs/privacy-policy.md\` | 英語（このページは英語のみ） |

副次効果として SEO meta タグ・OGP も正しい言語になる。

## Test plan

- [x] 既存自動テスト 394 件全件パス（\`npm test\`）
- [ ] マージ後、Pages ビルド完了を待ってから実機確認:
  - [ ] \`index.en.html\` のサブタイトルが英語になっている
  - [ ] \`RELEASE_NOTES.en.html\` も同様
  - [ ] 日本語ページは引き続き日本語で表示される
  - [ ] DevTools で \`<meta name=\"description\">\` も言語に合わせて切り替わっている

> テストプラン / 自動テスト / 手動テストシナリオの追加・更新はスキップ。
> 根拠: GitHub Pages の Markdown フロントマター変更のみで、拡張本体の挙動・ビルドには一切影響しない。

closes #111