### PR TITLE
docs: GitHub Pages index に safeAttach・xgate4 のプロダクトカードバナーを追加

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -31,4 +31,19 @@ Source code is on GitHub:
 
 ## Developer
 
-DualView Translator is developed by [Orangesoft Inc.](https://www.orangesoft.co.jp/) — also makers of [safeAttach](https://www.orangesoft.co.jp/safeattach) and [xgate4](https://www.orangesoft.co.jp/xgate).
+DualView Translator is developed by [Orangesoft Inc.](https://www.orangesoft.co.jp/)
+
+## More from Orangesoft
+
+<div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin:1.5rem 0;">
+  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
+    <h3 style="margin-top:0; color:#e67e00;">🔒 safeAttach</h3>
+    <p style="margin-bottom:1rem;">Stop accidental email leaks before they happen — secure attachment encryption and recipient verification built right in.</p>
+    <a href="https://www.orangesoft.co.jp/safeattach" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">Learn more →</a>
+  </div>
+  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
+    <h3 style="margin-top:0; color:#e67e00;">✉️ xgate4</h3>
+    <p style="margin-bottom:1rem;">A webmail solution for business — access your email securely from any browser, anywhere.</p>
+    <a href="https://www.orangesoft.co.jp/xgate" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">Learn more →</a>
+  </div>
+</div>

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -35,15 +35,23 @@ DualView Translator is developed by [Orangesoft Inc.](https://www.orangesoft.co.
 
 ## More from Orangesoft
 
-<div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin:1.5rem 0;">
-  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
-    <h3 style="margin-top:0; color:#e67e00;">🔒 safeAttach</h3>
-    <p style="margin-bottom:1rem;">Stop accidental email leaks before they happen — secure attachment encryption and recipient verification built right in.</p>
-    <a href="https://www.orangesoft.co.jp/safeattach" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">Learn more →</a>
+<style>
+.dvt-product-grid { display:flex; gap:1.5rem; flex-wrap:wrap; margin:1.5rem 0; }
+.dvt-product-card { flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08); }
+.dvt-product-title { margin-top:0; color:#a64b00; }
+.dvt-product-desc { margin-bottom:1rem; }
+.dvt-product-btn { display:inline-block; padding:0.5em 1.1em; background:#a64b00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold; }
+</style>
+
+<div class="dvt-product-grid">
+  <div class="dvt-product-card">
+    <h3 class="dvt-product-title">🔒 safeAttach</h3>
+    <p class="dvt-product-desc">Stop accidental email leaks before they happen — secure attachment encryption and recipient verification built right in.</p>
+    <a href="https://www.orangesoft.co.jp/safeattach" class="dvt-product-btn">Learn more →</a>
   </div>
-  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
-    <h3 style="margin-top:0; color:#e67e00;">✉️ xgate4</h3>
-    <p style="margin-bottom:1rem;">A webmail solution for business — access your email securely from any browser, anywhere.</p>
-    <a href="https://www.orangesoft.co.jp/xgate" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">Learn more →</a>
+  <div class="dvt-product-card">
+    <h3 class="dvt-product-title">✉️ xgate4</h3>
+    <p class="dvt-product-desc">A webmail solution for business — access your email securely from any browser, anywhere.</p>
+    <a href="https://www.orangesoft.co.jp/xgate" class="dvt-product-btn">Learn more →</a>
   </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,15 +35,23 @@ DualView Translator は[株式会社オレンジソフト](https://www.orangesof
 
 ## Orangesoft の他の製品
 
-<div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin:1.5rem 0;">
-  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
-    <h3 style="margin-top:0; color:#e67e00;">🔒 safeAttach</h3>
-    <p style="margin-bottom:1rem;">メール誤送信防止・添付ファイル暗号化ソリューション。うっかりミスによる情報漏洩を防ぎます。</p>
-    <a href="https://www.orangesoft.co.jp/safeattach" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">詳しく見る →</a>
+<style>
+.dvt-product-grid { display:flex; gap:1.5rem; flex-wrap:wrap; margin:1.5rem 0; }
+.dvt-product-card { flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08); }
+.dvt-product-title { margin-top:0; color:#a64b00; }
+.dvt-product-desc { margin-bottom:1rem; }
+.dvt-product-btn { display:inline-block; padding:0.5em 1.1em; background:#a64b00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold; }
+</style>
+
+<div class="dvt-product-grid">
+  <div class="dvt-product-card">
+    <h3 class="dvt-product-title">🔒 safeAttach</h3>
+    <p class="dvt-product-desc">メール誤送信防止・添付ファイル暗号化ソリューション。うっかりミスによる情報漏洩を防ぎます。</p>
+    <a href="https://www.orangesoft.co.jp/safeattach" class="dvt-product-btn">詳しく見る →</a>
   </div>
-  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
-    <h3 style="margin-top:0; color:#e67e00;">✉️ xgate4</h3>
-    <p style="margin-bottom:1rem;">企業向けWebメールソフト。ブラウザからいつでもどこでも安全にメールを利用できます。</p>
-    <a href="https://www.orangesoft.co.jp/xgate" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">詳しく見る →</a>
+  <div class="dvt-product-card">
+    <h3 class="dvt-product-title">✉️ xgate4</h3>
+    <p class="dvt-product-desc">企業向けWebメールソフト。ブラウザからいつでもどこでも安全にメールを利用できます。</p>
+    <a href="https://www.orangesoft.co.jp/xgate" class="dvt-product-btn">詳しく見る →</a>
   </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,4 +32,18 @@ Copyright (c) Orangesoft Inc.
 ## 開発元
 
 DualView Translator は[株式会社オレンジソフト](https://www.orangesoft.co.jp/)が開発しています。
-他にも [safeAttach](https://www.orangesoft.co.jp/safeattach)、[xgate4](https://www.orangesoft.co.jp/xgate) などのソフトウェアを提供しています。
+
+## Orangesoft の他の製品
+
+<div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin:1.5rem 0;">
+  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
+    <h3 style="margin-top:0; color:#e67e00;">🔒 safeAttach</h3>
+    <p style="margin-bottom:1rem;">メール誤送信防止・添付ファイル暗号化ソリューション。うっかりミスによる情報漏洩を防ぎます。</p>
+    <a href="https://www.orangesoft.co.jp/safeattach" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">詳しく見る →</a>
+  </div>
+  <div style="flex:1; min-width:240px; border:1px solid #ddd; border-radius:8px; padding:1.25rem; box-shadow:0 2px 6px rgba(0,0,0,0.08);">
+    <h3 style="margin-top:0; color:#e67e00;">✉️ xgate4</h3>
+    <p style="margin-bottom:1rem;">企業向けWebメールソフト。ブラウザからいつでもどこでも安全にメールを利用できます。</p>
+    <a href="https://www.orangesoft.co.jp/xgate" style="display:inline-block; padding:0.5em 1.1em; background:#e67e00; color:#fff; border-radius:5px; text-decoration:none; font-weight:bold;">詳しく見る →</a>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- `docs/index.md` / `docs/index.en.md` の「開発元」末尾テキストリンクを廃止
- 「Orangesoft の他の製品」（英語: "More from Orangesoft"）セクションを新設
- safeAttach・xgate4 をカード型バナー（見出し＋説明文＋オレンジボタン）で横並び表示
- `flex-wrap` によりモバイルは縦積みに自動対応

## Test plan

- [ ] GitHub Pages デプロイ後、`/index.html` でカードが横並びに表示されること
- [ ] モバイル幅（360px 程度）で縦積みになること
- [ ] 各カードのリンクボタンが正しい URL に遷移すること
- [ ] 英語ページ（`/index.en.html`）も同様に表示されること

closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)