### PR TITLE
chore: iOS / macOS Safari 拡張のバージョンを 1.4 に更新

### DIFF
--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -694,7 +694,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -706,7 +706,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -729,7 +729,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -741,7 +741,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -767,7 +767,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -783,7 +783,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -810,7 +810,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -826,7 +826,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -852,7 +852,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -877,7 +877,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -900,7 +900,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -925,7 +925,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -950,7 +950,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -968,7 +968,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -995,7 +995,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1013,7 +1013,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
## Summary

iOS Safari 版が v1.0 で App Store 配信開始されたあとに v1.4.0 へ大量の改善（#93 / #102 等）が入ったため、Safari Xcode プロジェクトの \`MARKETING_VERSION\` を \`1.0\` → \`1.4\` に更新して再申請の準備を整える。

macOS Safari は v1.0 が Mac App Store 審査中だが、同じ Xcode プロジェクトなので併せて更新（macOS の v1.0 審査が通った後、続けて 1.4 を提出する流れ）。

### 変更内容

\`safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj\`（各 8 箇所）:

- \`MARKETING_VERSION\`: \`1.0\` → \`1.4\`（拡張本体 \`manifest.json\` / \`package.json\` の \`1.4.0\` と同期）
- \`CURRENT_PROJECT_VERSION\` (Build): \`2\` → \`3\`

### 拡張本体の反映

Xcode プロジェクトはリポジトリ直下のファイルを直接参照（\`path = ../../../manifest.json\` など）しているため、Archive 時に最新の content-* / _locales / icons / 選択翻訳ミニアイコン UI が自動で取り込まれる。コピー作業は不要。

### バージョニング方針

- \`1.0\` → \`1.4\` のジャンプは、拡張本体（\`1.4.0\`）と Safari Marketing Version を揃えるため。中間の 1.1〜1.3 はスキップ
- 今後は拡張本体と Safari Marketing Version を同期させる運用にする

### スコープ外

- 実際の Archive / App Store Connect 提出は人間が Xcode から行う
- macOS は v1.0 審査が通った後に v1.4 を続けて提出する想定

## Test plan

- [x] \`xcodebuild -scheme \"DualView Translator (macOS)\" build\` → **BUILD SUCCEEDED**
- [x] \`npm test\`（既存自動テスト 394 件全件パス）
- [ ] マージ後、人間が Xcode から Archive → App Store Connect にアップロード

> テストプラン / 自動テスト / 手動テストシナリオの追加・更新はスキップ。
> 根拠: Safari Xcode プロジェクトのバージョン番号変更のみで、拡張本体ロジック・自動テスト対象には影響しない。

closes #117