### PR TITLE
fix: _locales の description が Apple Safari の 112 文字制限を超えていてアップロードが失敗する問題を修正

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "إضافة ترجمة للمتصفح تعرض النص الأصلي والترجمة جنبًا إلى جنب. تدعم ترجمة التحديد وترجمة الصفحة بأكملها.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "تبديل ترجمة الصفحة بأكملها",

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "Browser-Übersetzungserweiterung, die Original und Übersetzung nebeneinander anzeigt. Unterstützt Auswahl- und Ganzseitenübersetzung.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "Ganzseitenübersetzung umschalten",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "Browser translation extension that shows the original and translation side by side. Supports text selection and full-page translation.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "Toggle full-page translation",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "Extensión de traducción del navegador que muestra el original y la traducción en paralelo. Admite traducción de selección y de página completa.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "Alternar la traducción de la página",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "Extension de traduction qui affiche l'original et la traduction côte à côte. Prend en charge la traduction de la sélection et de la page entière.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "Activer/désactiver la traduction de la page",

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "원문과 번역을 나란히 보여주는 브라우저 번역 확장. 선택 번역과 전체 페이지 번역을 지원합니다.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "전체 페이지 번역 전환",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "Extensão de tradução para navegador que exibe o original e a tradução lado a lado. Suporta tradução de seleção e de página inteira.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "Alternar tradução da página",

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "Расширение браузера для перевода, отображающее оригинал и перевод рядом. Поддерживает перевод выделенного текста и всей страницы.",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "Переключить перевод страницы",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "并排显示原文和译文的浏览器翻译扩展。支持划词翻译和整页翻译。",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "切换整页翻译",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,7 +1,7 @@
 {
   "extDescription": {
     "message": "並排顯示原文和譯文的瀏覽器翻譯擴充功能。支援選取翻譯和整頁翻譯。",
-    "description": "Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list."
+    "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {
     "message": "切換整頁翻譯",

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -117,4 +117,19 @@ describe('_locales — 拡張機能の i18n 化', () => {
         .toMatch(/^__MSG_\w+__$/);
     }
   });
+
+  // Apple Safari Web Extension のアップロードバリデーションは
+  // _locales/<lang>/messages.json の各エントリの description を必須かつ 112 文字以下に制限する。
+  // Chrome / Firefox では optional / 制限なしのため、これを超えても気付きにくい（実際 #119 で発覚）。
+  it('全 locale の全エントリに 112 文字以下の description プロパティがある（Apple Safari 制限）', () => {
+    const APPLE_DESCRIPTION_LIMIT = 112;
+    for (const locale of locales) {
+      const messages = loadMessages(locale);
+      for (const [key, value] of Object.entries(messages)) {
+        expect(typeof value.description, `${locale}.${key}.description が文字列でない`).toBe('string');
+        expect(value.description.length, `${locale}.${key}.description が ${APPLE_DESCRIPTION_LIMIT} 文字を超えている (${value.description.length} chars)`)
+          .toBeLessThanOrEqual(APPLE_DESCRIPTION_LIMIT);
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

iOS Safari v1.4 を App Store Connect にアップロードしようとすると以下のエラーで失敗していた:

\`\`\`
Invalid messages file. The messages.json validation failed for locale en in the Safari
web extension bundle DualView Translator.app/PlugIns/DualView Translator Extension.appex.
The description field must be present, of string type, and 112 or fewer characters long.
(code 90862)
\`\`\`

### 原因

\`_locales/<lang>/messages.json\` の \`extDescription.description\` が、日本語以外の **全 10 言語で 114 文字** あり、Apple Safari の 112 文字制限を 2 文字超過していた:

\`\`\`
Extension description shown in the Chrome Web Store / Firefox Add-ons listing and in the browser's extension list.
\`\`\` (114 chars)

\`description\` フィールドは Chrome / Firefox では optional / 長さ制限なしのため、これまでバリデーションを通過していた。Apple Safari Web Extension の Validation だけがこの制限を持つ（[Safari Web Extensions ドキュメント](https://developer.apple.com/documentation/safariservices/safari_web_extensions/assessing_your_safari_web_extension_s_browser_compatibility)）。

### 修正

- 全 11 言語の \`extDescription.description\` を **69 文字** の同じ短い文に統一:
  \`Description shown in store listings and the browser's extension list.\`
- \`tests/locales.test.js\` に「全 description が 112 文字以下」チェックを追加して回帰防止

### 影響範囲

| | 影響 |
|---|---|
| Chrome / Firefox 動作 | 影響なし（description は元々非表示の翻訳者向け注記） |
| App Store Connect アップロード | 通るようになる |
| 自動テスト | 1 件追加（394 → 395 全件パス） |

## Test plan

- [x] 既存自動テスト 395 件全件パス（\`npm test\`）
- [x] \`xcodebuild ... build\` （iOS / macOS）が引き続き成功する
- [ ] マージ後、Xcode で再 Archive → App Store Connect アップロードが成功することを確認

> テストプラン / 手動テストシナリオの追加・更新はスキップ。
> 根拠: ユーザー非表示の \`description\` フィールド（翻訳者向け注記）の文言短縮のみで、UI / 挙動には影響しない。回帰防止の自動テストは追加済み。

closes #119