### PR TITLE
fix: extDescription.message を Apple Safari の 112 文字制限以下に短縮（PR #120 follow-up）

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,6 +1,6 @@
 {
   "extDescription": {
-    "message": "Browser-Übersetzungserweiterung, die Original und Übersetzung nebeneinander anzeigt. Unterstützt Auswahl- und Ganzseitenübersetzung.",
+    "message": "Browser-Übersetzung mit Original und Übersetzung nebeneinander. Auswahl- und Ganzseitenmodus.",
     "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extDescription": {
-    "message": "Browser translation extension that shows the original and translation side by side. Supports text selection and full-page translation.",
+    "message": "Browser translation that shows the original and translation side by side. Selection and full-page modes.",
     "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,6 +1,6 @@
 {
   "extDescription": {
-    "message": "Extensión de traducción del navegador que muestra el original y la traducción en paralelo. Admite traducción de selección y de página completa.",
+    "message": "Extensión que muestra el original y la traducción lado a lado. Modos de selección y página completa.",
     "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
   "extDescription": {
-    "message": "Extension de traduction qui affiche l'original et la traduction côte à côte. Prend en charge la traduction de la sélection et de la page entière.",
+    "message": "Traduction qui affiche l'original et la traduction côte à côte. Modes sélection et page entière.",
     "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,6 +1,6 @@
 {
   "extDescription": {
-    "message": "Extensão de tradução para navegador que exibe o original e a tradução lado a lado. Suporta tradução de seleção e de página inteira.",
+    "message": "Extensão que exibe o original e a tradução lado a lado. Suporta seleção e página inteira.",
     "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,6 +1,6 @@
 {
   "extDescription": {
-    "message": "Расширение браузера для перевода, отображающее оригинал и перевод рядом. Поддерживает перевод выделенного текста и всей страницы.",
+    "message": "Браузерный перевод с оригиналом и переводом рядом. Поддерживает выделение и всю страницу.",
     "description": "Description shown in store listings and the browser's extension list."
   },
   "cmdTogglePageTranslateDescription": {

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -132,4 +132,18 @@ describe('_locales — 拡張機能の i18n 化', () => {
       }
     }
   });
+
+  // Apple は \"description field\" として extDescription.message そのものも 112 文字以下に制限する
+  // （manifest.json の description: \"__MSG_extDescription__\" が参照する本文）。
+  // Chrome Web Store / Firefox AMO では 132 文字許容のため気付きにくい（実際 #121 で発覚）。
+  it('全 locale の extDescription.message が 112 文字以下である（Apple Safari 制限）', () => {
+    const APPLE_MESSAGE_LIMIT = 112;
+    for (const locale of locales) {
+      const messages = loadMessages(locale);
+      const msg = messages.extDescription?.message ?? '';
+      expect(typeof msg, `${locale}.extDescription.message が文字列でない`).toBe('string');
+      expect(msg.length, `${locale}.extDescription.message が ${APPLE_MESSAGE_LIMIT} 文字を超えている (${msg.length} chars)`)
+        .toBeLessThanOrEqual(APPLE_MESSAGE_LIMIT);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

PR #120 後も iOS Safari v1.4 のアップロードが同じエラー（code 90862）で失敗する問題を修正。

### 真の原因

Apple のエラー \"description field\" は messages.json の翻訳者向け注記ではなく、**\`extDescription.message\`**（拡張機能の説明本文）を指していた。

各言語の \`extDescription.message\` 長:

| locale | before | after | 状態 |
|---|---|---|---|
| ar    | 102 | 102 | OK（変更なし） |
| de    | **132** | 93  | 修正 |
| en    | **134** | 104 | 修正 |
| es    | **143** | 100 | 修正 |
| fr    | **145** | 96  | 修正 |
| ja    | 38  | 38  | OK |
| ko    | 53  | 53  | OK |
| pt_BR | **131** | 89  | 修正 |
| ru    | **129** | 89  | 修正 |
| zh_CN | 30  | 30  | OK |
| zh_TW | 32  | 32  | OK |

### 文言方針

意図を保ちながら簡潔化:
- 「原文と翻訳を並べて表示」の核心メッセージは維持
- 「選択翻訳 + ページ全体翻訳」の機能列挙も保持
- 例（en）: \"Browser translation that shows the original and translation side by side. Selection and full-page modes.\" (104 chars)

### 回帰防止

\`tests/locales.test.js\` に「全 locale の \`extDescription.message\` が 112 文字以下」チェックを追加。これで今後この制限を踏むと CI で気付ける。PR #120 の \`description\` フィールドチェックも残す。

## Test plan

- [x] 既存自動テスト 396 件全件パス（\`npm test\`、+1 件）
- [x] \`xcodebuild ... -scheme \"DualView Translator (macOS)\" build\` → **BUILD SUCCEEDED**
- [ ] マージ後、Xcode で再 Archive → App Store Connect アップロードが成功することを確認

> テストプラン / 手動テストシナリオの追加・更新はスキップ。
> 根拠: ストア掲載文の文字数調整のみで、UI / 挙動は変わらない。回帰防止の自動テストは追加済み。

closes #121