### PR TITLE
chore: ストア掲載文の Apple 112 文字制限を .claude/rules/git.md に明文化

### DIFF
--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -76,32 +76,32 @@ test: content-bar の waitForElement テストを追加
 
 ## ストア掲載文の文字数制限
 
-`_locales/<lang>/messages.json` および `manifest.json` から参照されるストア掲載文（特に拡張機能の説明本文）は、**全 11 言語で 112 文字以下** に揃える。
+`_locales/<lang>/messages.json` および `manifest.json` から参照されるストア掲載文（特に拡張機能の説明本文）は、**全言語で 112 文字以下** に揃える。
 
 ### 制限の根拠
 
 | ストア | 上限 | 実害 |
 |---|---|---|
-| **Apple App Store**（Safari Web Extension）| **112** | これを超えると \`xcrun altool\`/Xcode のアップロードが \`code 90862\` で **失敗する** |
+| **Apple App Store**（Safari Web Extension）| **112** | これを超えると `xcrun altool`/Xcode のアップロードが `code 90862` で **失敗する** |
 | Chrome Web Store | 132 | 超えると Web Store ダッシュボードで弾かれる |
 | Firefox AMO | 132（要約欄）| 同上 |
 
-最小公倍数は Apple の **112 文字**。これを越えると iOS / macOS Safari のリリースが完全にブロックされる。
+最も厳しい上限は Apple の **112 文字**。これを超えると iOS / macOS Safari のリリースが完全にブロックされる。
 
 ### 対象フィールド
 
-- `_locales/<lang>/messages.json` の **`extDescription.message`**（\`manifest.json\` の \`description\` から \`__MSG_extDescription__\` で参照される本文）
+- `_locales/<lang>/messages.json` の **`extDescription.message`**（`manifest.json` の `description` から `__MSG_extDescription__` で参照される本文）
 - `_locales/<lang>/messages.json` の各エントリの **`description`** フィールド（翻訳者向け注記。Apple は注記もこの 112 制限を要求する）
 
 ### 自動チェック
 
 `tests/locales.test.js` に下記のテストが含まれており、`npm test` でガードされる:
 
-- 「全 locale の \`extDescription.message\` が 112 文字以下」
-- 「全 locale の全エントリの \`description\` が 112 文字以下」
+- 「全 locale の `extDescription.message` が 112 文字以下」
+- 「全 locale の全エントリの `description` が 112 文字以下」
 
 新言語追加・文言改訂時は CI で自動検出される。
 
 ### 経緯
 
-PR #119 / #121 で 2 連続でこの制限を踏んで iOS Safari v1.4 のアップロードが失敗した。Chrome / Firefox では超過しても気付けないため、必ず Apple の 112 を上限ルールにする。
+Issue #119 / #121（PR #120 / #122）で 2 連続でこの制限を踏んで iOS Safari v1.4 のアップロードが失敗した。Chrome / Firefox では超過しても気付けないため、必ず Apple の 112 を上限ルールにする。

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -73,3 +73,35 @@ test: content-bar の waitForElement テストを追加
 ```
 
 詳細は `.claude/skills/release.md` の手順 5 を参照。
+
+## ストア掲載文の文字数制限
+
+`_locales/<lang>/messages.json` および `manifest.json` から参照されるストア掲載文（特に拡張機能の説明本文）は、**全 11 言語で 112 文字以下** に揃える。
+
+### 制限の根拠
+
+| ストア | 上限 | 実害 |
+|---|---|---|
+| **Apple App Store**（Safari Web Extension）| **112** | これを超えると \`xcrun altool\`/Xcode のアップロードが \`code 90862\` で **失敗する** |
+| Chrome Web Store | 132 | 超えると Web Store ダッシュボードで弾かれる |
+| Firefox AMO | 132（要約欄）| 同上 |
+
+最小公倍数は Apple の **112 文字**。これを越えると iOS / macOS Safari のリリースが完全にブロックされる。
+
+### 対象フィールド
+
+- `_locales/<lang>/messages.json` の **`extDescription.message`**（\`manifest.json\` の \`description\` から \`__MSG_extDescription__\` で参照される本文）
+- `_locales/<lang>/messages.json` の各エントリの **`description`** フィールド（翻訳者向け注記。Apple は注記もこの 112 制限を要求する）
+
+### 自動チェック
+
+`tests/locales.test.js` に下記のテストが含まれており、`npm test` でガードされる:
+
+- 「全 locale の \`extDescription.message\` が 112 文字以下」
+- 「全 locale の全エントリの \`description\` が 112 文字以下」
+
+新言語追加・文言改訂時は CI で自動検出される。
+
+### 経緯
+
+PR #119 / #121 で 2 連続でこの制限を踏んで iOS Safari v1.4 のアップロードが失敗した。Chrome / Firefox では超過しても気付けないため、必ず Apple の 112 を上限ルールにする。


### PR DESCRIPTION
## Summary

PR #120 / #122 で対応した「\`_locales/<lang>/messages.json\` の文字数が Apple Safari の 112 文字制限を超えると iOS / macOS Safari の App Store Connect アップロードが \`code 90862\` で失敗する」問題を、運用ルールとして \`.claude/rules/git.md\` に明文化する。

### 追加した内容

\`.claude/rules/git.md\` の「リリースノート運用ルール」の後に「ストア掲載文の文字数制限」セクションを追加。

- 各ストアの制限値表（Apple = 112 / Chrome = 132 / Firefox = 132）
- 対象フィールド（\`extDescription.message\` と各エントリの \`description\`）
- 自動チェックの所在（\`tests/locales.test.js\`）
- 経緯（#119 / #121）

### 期待効果

- 新言語追加・文言改訂時に「全言語 112 文字以下」を意識できる
- \`tests/locales.test.js\` のチェックも残っているので、誤って超過したときは CI で検知される

## Test plan

- [x] 既存自動テスト 396 件全件パス（\`npm test\`）

> テスト・ドキュメント追加更新はスキップ。
> 根拠: \`.claude/rules/\` 配下の運用ルール文書化のみで、コード・自動テスト・拡張本体には影響しない。

closes #123