### PR TITLE
test: extDescription.message の存在チェックを明示化（PR #122 follow-up）

### DIFF
--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -136,12 +136,17 @@ describe('_locales — 拡張機能の i18n 化', () => {
   // Apple は \"description field\" として extDescription.message そのものも 112 文字以下に制限する
   // （manifest.json の description: \"__MSG_extDescription__\" が参照する本文）。
   // Chrome Web Store / Firefox AMO では 132 文字許容のため気付きにくい（実際 #121 で発覚）。
-  it('全 locale の extDescription.message が 112 文字以下である（Apple Safari 制限）', () => {
+  it('全 locale の extDescription.message が存在し 112 文字以下である（Apple Safari 制限）', () => {
     const APPLE_MESSAGE_LIMIT = 112;
     for (const locale of locales) {
       const messages = loadMessages(locale);
-      const msg = messages.extDescription?.message ?? '';
-      expect(typeof msg, `${locale}.extDescription.message が文字列でない`).toBe('string');
+      // optional chaining + ?? '' だと extDescription が欠けても通ってしまうため、
+      // 「存在 → 非 null → object → message が文字列 → 長さ <= 112」を明示的に検証
+      expect(messages.extDescription, `${locale}.extDescription が存在しない`).toBeDefined();
+      expect(messages.extDescription, `${locale}.extDescription が null`).not.toBeNull();
+      expect(typeof messages.extDescription, `${locale}.extDescription がオブジェクトでない`).toBe('object');
+      expect(typeof messages.extDescription.message, `${locale}.extDescription.message が文字列でない`).toBe('string');
+      const msg = messages.extDescription.message;
       expect(msg.length, `${locale}.extDescription.message が ${APPLE_MESSAGE_LIMIT} 文字を超えている (${msg.length} chars)`)
         .toBeLessThanOrEqual(APPLE_MESSAGE_LIMIT);
     }


### PR DESCRIPTION
## Summary

PR #122 でマージした「\`全 locale の extDescription.message が 112 文字以下である\`」テストの強度を上げる。Copilot レビュー（マージ後）で指摘された follow-up 対応。

### 元の問題

\`\`\`js
const msg = messages.extDescription?.message ?? '';
expect(msg.length, ...).toBeLessThanOrEqual(112);
\`\`\`

\`extDescription\` 自体や \`extDescription.message\` が欠けていても空文字（length 0）として通ってしまうため、テスト名「\`extDescription.message\` が **存在し** 112 文字以下」の意図を満たさない。

### 修正

5 段階で明示的に検証:

1. \`messages.extDescription\` が \`toBeDefined()\`
2. \`messages.extDescription\` が \`not.toBeNull()\`（\`typeof null === 'object'\` 対策）
3. \`typeof messages.extDescription === 'object'\`
4. \`typeof messages.extDescription.message === 'string'\`
5. \`messages.extDescription.message.length <= 112\`

テスト名にも「存在し」を追加して意図を明確化。

## Test plan

- [x] 既存自動テスト 396 件全件パス（\`npm test\`、変動なし）

> テスト・ドキュメントの追加更新はスキップ。
> 根拠: 既存テストの強度を上げるだけで、コード・拡張本体・ストア掲載文には影響しない。

closes #125