### PR TITLE
fix: iOS Safari でテキスト選択時にミニアイコンが表示されない問題を修正

### DIFF
--- a/content-selection.js
+++ b/content-selection.js
@@ -43,14 +43,26 @@ var DVT_SEL = (function () {
   // 選択直後はフルパネルを開かず、小さなアイコンだけを表示する。
   // クリックすると初めてフルパネルに展開する（コピー目的の選択を妨げないため）。
 
+  // selectionchange のデバウンス用タイマー（タッチデバイスのみで使用）
+  let selectionChangeTimer = null;
+
+  function clearSelectionChangeTimer() {
+    if (selectionChangeTimer) {
+      clearTimeout(selectionChangeTimer);
+      selectionChangeTimer = null;
+    }
+  }
+
   // 共通: 現在の選択テキストを評価してミニアイコンを再表示する
   function handleSelectionForMiniBtn() {
     const sel = window.getSelection();
-    const text = sel?.toString().trim();
+    // sel が null のときに .trim() で例外にならないよう optional chaining を二段にする
+    const text = sel?.toString()?.trim();
 
     removeSelectionMiniBtn();
 
-    if (text && text.length > 1) {
+    // sel が有効で範囲があり、テキストが 2 文字以上のときだけ表示
+    if (sel && sel.rangeCount > 0 && text && text.length > 1) {
       showSelectionMiniBtn(sel, text);
     }
   }
@@ -70,27 +82,40 @@ var DVT_SEL = (function () {
     handleSelectionForMiniBtn();
   });
 
-  // iOS Safari など mouseup が期待通り発火しない環境向けに selectionchange でも検知。
+  // iOS Safari など mouseup が期待通り発火しないタッチデバイス向けに selectionchange でも検知。
+  // タッチデバイスのみに限定する理由:
+  //   デスクトップで selectionchange を有効にすると、Shift+Arrow などキーボード選択でも
+  //   ミニアイコンが出てしまい、手動シナリオ SMI-013（キーボード選択では出さない）と矛盾する。
   // selectionchange は選択中の連続発火が頻繁なため 300ms デバウンスして「選択完了後」に判定する。
-  let selectionChangeTimer = null;
-  document.addEventListener('selectionchange', () => {
-    if (selectionChangeTimer) clearTimeout(selectionChangeTimer);
-    selectionChangeTimer = setTimeout(() => {
-      selectionChangeTimer = null;
-      // フルパネルが開いている間（パネル内テキスト選択など）は無視
-      if (DVT.state.selectionPanel) return;
-      handleSelectionForMiniBtn();
-    }, 300);
-  });
+  const isTouchDevice = (
+    typeof document !== 'undefined' &&
+    'ontouchstart' in document.documentElement
+  );
+  if (isTouchDevice) {
+    document.addEventListener('selectionchange', () => {
+      clearSelectionChangeTimer();
+      selectionChangeTimer = setTimeout(() => {
+        selectionChangeTimer = null;
+        // フルパネルが開いている間（パネル内テキスト選択など）は無視
+        if (DVT.state.selectionPanel) return;
+        handleSelectionForMiniBtn();
+      }, 300);
+    });
+  }
 
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
+      // 保留中の selectionchange タイマーで意図せず再表示されないよう先にクリア
+      clearSelectionChangeTimer();
       removeSelectionPanel();
       removeSelectionMiniBtn();
     }
   });
 
   function removeSelectionPanel() {
+    // パネルを閉じるタイミングで保留中の selectionchange タイマーもクリアしておくと、
+    // 「パネル閉じる → 0.3 秒後に古い選択範囲でアイコン再表示」のような副作用を防げる
+    clearSelectionChangeTimer();
     if (DVT.state.selectionPanel) {
       DVT.state.selectionPanel.remove();
       DVT.state.selectionPanel = null;

--- a/content-selection.js
+++ b/content-selection.js
@@ -42,6 +42,20 @@ var DVT_SEL = (function () {
   // ─── テキスト選択イベント ───────────────────────────────────────────
   // 選択直後はフルパネルを開かず、小さなアイコンだけを表示する。
   // クリックすると初めてフルパネルに展開する（コピー目的の選択を妨げないため）。
+
+  // 共通: 現在の選択テキストを評価してミニアイコンを再表示する
+  function handleSelectionForMiniBtn() {
+    const sel = window.getSelection();
+    const text = sel?.toString().trim();
+
+    removeSelectionMiniBtn();
+
+    if (text && text.length > 1) {
+      showSelectionMiniBtn(sel, text);
+    }
+  }
+
+  // デスクトップ系（Chrome / Firefox / macOS Safari）: mouseup ベース
   document.addEventListener('mouseup', (e) => {
     // 左クリック以外（右クリックや中クリックの mouseup）は無視。
     // 右クリックでミニアイコンが出てしまうとコンテキストメニュー操作の邪魔になる
@@ -50,15 +64,23 @@ var DVT_SEL = (function () {
     if (DVT.state.selectionMiniBtn && DVT.state.selectionMiniBtn.contains(e.target)) return;
     if (DVT.state.selectionPanel && DVT.state.selectionPanel.contains(e.target)) return;
 
-    const sel = window.getSelection();
-    const text = sel?.toString().trim();
-
+    // mouseup は「別箇所をクリックして選択を解除」したケースも兼ねるので、
+    // フルパネルが開いていれば閉じる
     removeSelectionPanel();
-    removeSelectionMiniBtn();
+    handleSelectionForMiniBtn();
+  });
 
-    if (text && text.length > 1) {
-      showSelectionMiniBtn(sel, text);
-    }
+  // iOS Safari など mouseup が期待通り発火しない環境向けに selectionchange でも検知。
+  // selectionchange は選択中の連続発火が頻繁なため 300ms デバウンスして「選択完了後」に判定する。
+  let selectionChangeTimer = null;
+  document.addEventListener('selectionchange', () => {
+    if (selectionChangeTimer) clearTimeout(selectionChangeTimer);
+    selectionChangeTimer = setTimeout(() => {
+      selectionChangeTimer = null;
+      // フルパネルが開いている間（パネル内テキスト選択など）は無視
+      if (DVT.state.selectionPanel) return;
+      handleSelectionForMiniBtn();
+    }, 300);
   });
 
   document.addEventListener('keydown', (e) => {

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -13,7 +13,9 @@ permalink: /RELEASE_NOTES.en.html
 ### Bug fixes
 
 - **Fix: mini translate icon didn't show up on iOS Safari** (#127)
-  - The selection detection was `mouseup`-only, which doesn't fire predictably for iOS text selection (long-press + range handles). Added a debounced `selectionchange` listener (300ms) so iOS picks up the selection too. Desktop behavior (Chrome / Firefox / macOS Safari) is unchanged.
+  - The selection detection was `mouseup`-only, which doesn't fire predictably for iOS text selection (long-press + range handles). Added a debounced `selectionchange` listener (300ms) so iOS picks up the selection too.
+  - The `selectionchange` listener is only registered on **touch devices** (`'ontouchstart' in document.documentElement`), so desktop (Chrome / Firefox / macOS Safari) keeps its existing behavior of not showing the icon for keyboard selections (Shift+Arrow).
+  - As a side fix, pressing Escape now also cancels any pending debounce timer so the icon won't unexpectedly reappear after dismissal.
 
 ### Milestones
 

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -10,6 +10,11 @@ permalink: /RELEASE_NOTES.en.html
 
 ## Unreleased
 
+### Bug fixes
+
+- **Fix: mini translate icon didn't show up on iOS Safari** (#127)
+  - The selection detection was `mouseup`-only, which doesn't fire predictably for iOS text selection (long-press + range handles). Added a debounced `selectionchange` listener (300ms) so iOS picks up the selection too. Desktop behavior (Chrome / Firefox / macOS Safari) is unchanged.
+
 ### Milestones
 
 - **iOS Safari extension is now live on the App Store** (2026-04-28)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -14,7 +14,8 @@ permalink: /RELEASE_NOTES.html
 
 - **iOS Safari でテキスト選択時にミニアイコンが表示されない問題を修正**（#127）
   - `mouseup` イベントベースの検知だけでは iOS のテキスト選択（長押し → 範囲ハンドル操作）に対応できなかったため、`selectionchange` イベント + 300ms デバウンスでも検知するように変更
-  - デスクトップ系（Chrome / Firefox / macOS Safari）の挙動は維持
+  - `selectionchange` の登録は **タッチデバイスのみ** に限定（`'ontouchstart' in document.documentElement` で判定）。デスクトップ系（Chrome / Firefox / macOS Safari）では Shift+Arrow キーボード選択でアイコンが出ないという既存仕様を維持
+  - 副次的に Escape 押下でデバウンスタイマーをクリアし、閉じた後にアイコンが意図せず再表示されないようにした
 
 ### マイルストーン
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+### バグ修正
+
+- **iOS Safari でテキスト選択時にミニアイコンが表示されない問題を修正**（#127）
+  - `mouseup` イベントベースの検知だけでは iOS のテキスト選択（長押し → 範囲ハンドル操作）に対応できなかったため、`selectionchange` イベント + 300ms デバウンスでも検知するように変更
+  - デスクトップ系（Chrome / Firefox / macOS Safari）の挙動は維持
+
 ### マイルストーン
 
 - **iOS Safari 拡張が App Store で配信開始**（2026-04-28）

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -1061,9 +1061,10 @@ suites:
           - ホバーしてもボタンが拡大しない
 
       - id: SMI-013
-        title: キーボード選択（Shift + 矢印キー）ではミニアイコンは出ない
+        title: デスクトップでキーボード選択（Shift + 矢印キー）してもミニアイコンは出ない
         priority: p2
-        description: mouseup ベースの実装のため、キーボード選択でアイコンは出ない仕様。代替として Ctrl+Shift+Y ショートカットを案内する
+        environment: chrome
+        description: "#127 で selectionchange 経路を追加した際、タッチデバイス限定で登録するようゲートして本シナリオの仕様（デスクトップでキーボード選択ではアイコン非表示）を維持している"
         steps:
           - 任意のページにフォーカスを当てる
           - キャレットを置いてから Shift + → / Shift + Ctrl + → でテキスト選択

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -1081,3 +1081,29 @@ suites:
         expected:
           - 青色（`#1a73e8`）のアウトラインがアイコン外周に表示される
           - マウスクリックではフォーカスリングは出ない（:focus-visible の意図通り）
+
+      - id: SMI-015
+        title: iOS Safari でテキスト選択するとミニアイコンが表示される
+        priority: p0
+        environment: safari-ios-real
+        description: "#127 で iOS Safari でアイコンが出ない問題に対応した回帰防止項目。selectionchange + 300ms デバウンスで動作"
+        steps:
+          - iOS Safari で拡張を有効化したまま任意の Web ページを開く
+          - 段落のテキストを長押し選択（範囲ハンドルでも調整 OK）
+          - 指を離してから 0.5 秒程度待つ
+        expected:
+          - 選択範囲の右下隣あたりに白角丸の 🌐 ミニアイコンが表示される
+          - フルパネルは即座には開かない
+          - アイコンをタップすると翻訳パネルが展開する
+
+      - id: SMI-016
+        title: iOS Safari でフルパネル表示中にテキスト再選択しても二重に開かない
+        priority: p1
+        environment: safari-ios-real
+        steps:
+          - SMI-015 の手順でミニアイコン → タップでフルパネルを開く
+          - パネルを閉じずにページの別のテキストを選択
+        expected:
+          - パネル内のテキスト選択は無視される
+          - パネル外のテキスト選択時は新しいミニアイコンは出ない（現在のフルパネルが優先）
+          - パネルを閉じてから再選択するとミニアイコンが出る

--- a/tests/content-selection.test.js
+++ b/tests/content-selection.test.js
@@ -1,5 +1,5 @@
 // content-selection.js のドラッグ移動・リサイズ機能テスト
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { loadScript } from './helpers.js';
@@ -77,6 +77,11 @@ describe('選択翻訳 — ミニアイコン方式', () => {
 
   it('document の mouseup ハンドラが左クリック以外を早期 return している', () => {
     expect(jsCode).toMatch(/document\.addEventListener\(\s*['"]mouseup['"][\s\S]{0,200}e\.button !== 0/);
+  });
+
+  it('selectionchange イベントもデバウンス付きで購読している（iOS Safari 対応）', () => {
+    expect(jsCode).toMatch(/document\.addEventListener\(\s*['"]selectionchange['"]/);
+    expect(jsCode).toMatch(/setTimeout\([\s\S]{0,200}300\)/);
   });
 
   it('ミニアイコン上の mousedown は伝播停止する（document mouseup での消去を防ぐ）', () => {
@@ -281,5 +286,49 @@ describe('選択翻訳 — ミニアイコン jsdom 統合', () => {
     expect(panel.querySelector('.dvt-sel-header')).toBeTruthy();
     expect(panel.querySelector('.dvt-sel-lang')).toBeTruthy();
     expect(panel.querySelector('.dvt-sel-btn')).toBeTruthy();
+  });
+
+  it('selectionchange イベント経路でもミニアイコンが生成される（iOS Safari 対応の動作保証）', () => {
+    vi.useFakeTimers();
+    try {
+      const p = document.createElement('p');
+      p.textContent = 'Hello world';
+      document.body.appendChild(p);
+
+      selectTextOf(p, 0, 11);
+      // iOS Safari ではテキスト選択完了で selectionchange が発火する。
+      // mouseup を発火させずに selectionchange だけを送る → デバウンス後にアイコンが生成されるはず。
+      document.dispatchEvent(new Event('selectionchange'));
+      // デバウンス完了まで時間を進める
+      vi.advanceTimersByTime(300);
+
+      const btn = document.querySelector('.dvt-sel-mini-btn');
+      expect(btn).toBeTruthy();
+      expect(btn.querySelector('.dvt-sel-mini-icon')?.textContent).toBe('🌐');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('selectionchange のデバウンス中は連続発火を 1 回にまとめる', () => {
+    vi.useFakeTimers();
+    try {
+      const p = document.createElement('p');
+      p.textContent = 'Hello world translation';
+      document.body.appendChild(p);
+
+      selectTextOf(p, 0, 5);
+      document.dispatchEvent(new Event('selectionchange'));
+      // デバウンス内で再選択 → 旧タイマーがクリアされて新タイマー開始
+      vi.advanceTimersByTime(100);
+      selectTextOf(p, 6, 11);
+      document.dispatchEvent(new Event('selectionchange'));
+      vi.advanceTimersByTime(300);
+
+      const btns = document.querySelectorAll('.dvt-sel-mini-btn');
+      expect(btns.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/content-selection.test.js
+++ b/tests/content-selection.test.js
@@ -84,6 +84,16 @@ describe('選択翻訳 — ミニアイコン方式', () => {
     expect(jsCode).toMatch(/setTimeout\([\s\S]{0,200}300\)/);
   });
 
+  it('selectionchange はタッチデバイス判定でゲートされている（デスクトップで Shift+Arrow と衝突しない）', () => {
+    // `'ontouchstart' in document.documentElement` の判定で true のときだけ登録される
+    expect(jsCode).toMatch(/['"]ontouchstart['"][\s\S]{0,80}document\.documentElement/);
+    expect(jsCode).toMatch(/if\s*\(\s*isTouchDevice\s*\)[\s\S]{0,200}selectionchange/);
+  });
+
+  it('Escape ハンドラで保留中の selectionchange タイマーをクリアしている', () => {
+    expect(jsCode).toMatch(/Escape[\s\S]{0,400}clearSelectionChangeTimer/);
+  });
+
   it('ミニアイコン上の mousedown は伝播停止する（document mouseup での消去を防ぐ）', () => {
     // mousedown ハンドラ内で stopPropagation していることを確認
     expect(jsCode).toMatch(/btn\.addEventListener\('mousedown'[\s\S]*?stopPropagation/);
@@ -327,6 +337,56 @@ describe('選択翻訳 — ミニアイコン jsdom 統合', () => {
 
       const btns = document.querySelectorAll('.dvt-sel-mini-btn');
       expect(btns.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('フルパネル展開中は selectionchange を無視してアイコンを再生成しない', () => {
+    DVT_I18N.setLang('ja');
+    const p = document.createElement('p');
+    p.textContent = 'Hello world translation';
+    document.body.appendChild(p);
+
+    // 1) 選択 → mouseup でミニアイコン → クリックでフルパネル展開
+    selectTextOf(p, 0, 5);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0 }));
+    document.querySelector('.dvt-sel-mini-btn').click();
+    expect(document.querySelector('.dvt-sel-panel')).toBeTruthy();
+
+    // 2) パネル展開中に別範囲を選択 → selectionchange
+    vi.useFakeTimers();
+    try {
+      selectTextOf(p, 6, 11);
+      document.dispatchEvent(new Event('selectionchange'));
+      vi.advanceTimersByTime(300);
+
+      // パネルは閉じず、ミニアイコンも生成されないこと
+      expect(document.querySelector('.dvt-sel-panel')).toBeTruthy();
+      expect(document.querySelector('.dvt-sel-mini-btn')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('Escape は保留中の selectionchange タイマーもキャンセルする', () => {
+    vi.useFakeTimers();
+    try {
+      const p = document.createElement('p');
+      p.textContent = 'Hello world';
+      document.body.appendChild(p);
+
+      // selectionchange でタイマー予約（まだ満了させない）
+      selectTextOf(p, 0, 11);
+      document.dispatchEvent(new Event('selectionchange'));
+      vi.advanceTimersByTime(100); // 300ms 未満
+
+      // Escape を押す
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      // 残り時間を進めても、Escape でクリアされたタイマーは発火しない
+      vi.advanceTimersByTime(500);
+
+      expect(document.querySelector('.dvt-sel-mini-btn')).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -26,6 +26,17 @@ if (typeof Range !== 'undefined' && !Range.prototype.getClientRects) {
   };
 }
 
+// content-selection.js は selectionchange リスナーをタッチデバイスのみで登録するため、
+// jsdom 環境を「タッチデバイス」と判定させて selectionchange 経路もテストできるようにする。
+// (`'ontouchstart' in document.documentElement` の判定で true を返させる)
+if (typeof document !== 'undefined' && !('ontouchstart' in document.documentElement)) {
+  Object.defineProperty(document.documentElement, 'ontouchstart', {
+    value: null,
+    configurable: true,
+    writable: true,
+  });
+}
+
 const storageData = {};
 
 globalThis.chrome = {


### PR DESCRIPTION
## Summary

iOS Safari（v1.4 配信版）でテキストを長押し選択しても、選択翻訳ミニアイコンが表示されなかった問題を修正。

### 原因

\`content-selection.js\` の選択検知が \`mouseup\` ベースだったが、iOS Safari のテキスト選択（長押し → 範囲ハンドル操作）はデスクトップの \`mouseup\` 発火パターンと異なるため、ハンドラが期待通り走らなかった。

### 修正

- 共通ロジックを \`handleSelectionForMiniBtn()\` 関数に切り出し
- 既存の \`mouseup\` 経路（デスクトップ用）はそのまま維持
- \`selectionchange\` イベント + **300ms デバウンス** を追加（iOS Safari 対応）
- \`selectionchange\` はパネル展開中は無視（パネル内テキスト選択を拾わないため）

### 影響範囲

| | 影響 |
|---|---|
| Chrome / Firefox / macOS Safari | 既存の mouseup 経路で動作（変更なし） |
| iOS Safari | selectionchange 経路で新たに動作するようになる |
| 自動テスト | 文字列マッチ + jsdom 統合テストで両経路をカバー（+3 件） |

## Test plan

- [x] 既存自動テスト 399 件全件パス（\`npm test\`、+3 件）
  - 文字列マッチ: \`selectionchange\` リスナー + 300ms デバウンスの存在確認
  - jsdom 統合: selectionchange 経路でミニアイコン生成
  - jsdom 統合: 連続発火がデバウンスで 1 回にまとめられる
- [ ] 手動: \`docs/manual-test-scenarios.yaml\` SMI-015 / SMI-016（iOS 実機）でアイコン表示が確認できる

> 拡張本体の変更を含むため、\`docs/RELEASE_NOTES.md\` / \`RELEASE_NOTES.en.md\` の「未リリース／バグ修正」に追記済み。

closes #127