### PR TITLE
feat: Safari拡張ハンドラに Translation framework 疎通エンドポイント追加（#144 PoC）

### DIFF
--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -7,8 +7,11 @@
 
 import SafariServices
 import os.log
+// Translation framework は iOS 17.4+ / macOS 14.4+ にしか存在しないため、
+// strong link すると iOS 15 / macOS 10.14 など古い OS で dyld が拡張をロードできなくなる。
+// @_weakLinked により実体不在時もロードを許可し、availability ガードで実呼び出しを抑止する。
 #if canImport(Translation)
-import Translation
+@_weakLinked import Translation
 #endif
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
@@ -34,8 +37,9 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         // 本体は出力せず、存在有無とプロファイルIDのみデバッグレベルで記録する
         os_log(.debug, "Received message from browser.runtime.sendNativeMessage (hasMessage: %{public}@, profile: %{public}@)", message == nil ? "false" : "true", profile?.uuidString ?? "none")
 
-        // メッセージが { action, payload } 形式の場合は action でディスパッチ。
-        // それ以外（旧形式）は後方互換のため echo を返す。
+        // メッセージが { action: "...", ...パラメータ } 形式（フラット辞書）の場合は action でディスパッチ。
+        // 各 action に必要なパラメータ（source / target / text 等）はトップレベルから直接読み取る。
+        // action キーが無い旧形式メッセージは後方互換のため echo を返す。
         let payload = message as? [String: Any]
         let action = payload?["action"] as? String
 

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -7,6 +7,9 @@
 
 import SafariServices
 import os.log
+#if canImport(Translation)
+import Translation
+#endif
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
@@ -31,14 +34,121 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         // 本体は出力せず、存在有無とプロファイルIDのみデバッグレベルで記録する
         os_log(.debug, "Received message from browser.runtime.sendNativeMessage (hasMessage: %{public}@, profile: %{public}@)", message == nil ? "false" : "true", profile?.uuidString ?? "none")
 
-        let response = NSExtensionItem()
-        if #available(iOS 15.0, macOS 11.0, *) {
-            response.userInfo = [ SFExtensionMessageKey: [ "echo": message ] ]
-        } else {
-            response.userInfo = [ "message": [ "echo": message ] ]
+        // メッセージが { action, payload } 形式の場合は action でディスパッチ。
+        // それ以外（旧形式）は後方互換のため echo を返す。
+        let payload = message as? [String: Any]
+        let action = payload?["action"] as? String
+
+        // 同期で完結する action は即応答。非同期 API を呼ぶ action のみ Task で処理。
+        if let action = action {
+            switch action {
+            case "ping":
+                respond(context: context, body: handlePing())
+                return
+            case "checkLanguageAvailability":
+                // Task は macOS 10.15+ / iOS 13+ で利用可能。
+                // それ未満では Translation framework 自体も使えないので機能無効レスポンスを返す。
+                if #available(iOS 13.0, macOS 10.15, *) {
+                    Task {
+                        let body = await handleCheckLanguageAvailability(payload: payload ?? [:])
+                        respond(context: context, body: body)
+                    }
+                } else {
+                    respond(context: context, body: [
+                        "ok": false,
+                        "error": "Requires iOS 13+ / macOS 10.15+ runtime"
+                    ])
+                }
+                return
+            default:
+                // 未知の action は明示的にエラーを返す（黙って echo にフォールバックすると
+                // JS 側のバグに気付きにくくなるため）
+                respond(context: context, body: [
+                    "ok": false,
+                    "error": "unknown action: \(action)"
+                ])
+                return
+            }
         }
 
-        context.completeRequest(returningItems: [ response ], completionHandler: nil)
+        // 後方互換: action が無いメッセージは従来どおり echo する
+        respond(context: context, body: ["echo": message ?? NSNull()])
+    }
+
+    // ─── 共通レスポンダ ────────────────────────────────────────────
+    private func respond(context: NSExtensionContext, body: [String: Any]) {
+        let response = NSExtensionItem()
+        if #available(iOS 15.0, macOS 11.0, *) {
+            response.userInfo = [SFExtensionMessageKey: body]
+        } else {
+            response.userInfo = ["message": body]
+        }
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+
+    // ─── ping: ブリッジ動作確認 ────────────────────────────────────
+    // Translation framework が利用可能な OS かどうかをだけ返す軽量応答。
+    // 実機で「JS から呼んで戻ってくるか」を最初に確認するための健康診断用。
+    private func handlePing() -> [String: Any] {
+        var info: [String: Any] = [
+            "ok": true,
+            "osVersion": ProcessInfo.processInfo.operatingSystemVersionString,
+        ]
+        // Translation framework は iOS 17.4+ / macOS 14.4+ で導入。
+        // ただし LanguageAvailability などのプログラマティック API は iOS 18+ / macOS 15+ で追加されたため、
+        // 「フレームワーク自体の有無」と「programmatic API が使えるか」は別フラグで返す。
+        if #available(iOS 17.4, macOS 14.4, *) {
+            info["translationFrameworkAvailable"] = true
+        } else {
+            info["translationFrameworkAvailable"] = false
+        }
+        if #available(iOS 18.0, macOS 15.0, *) {
+            info["languageAvailabilityAPIAvailable"] = true
+        } else {
+            info["languageAvailabilityAPIAvailable"] = false
+        }
+        return info
+    }
+
+    // ─── checkLanguageAvailability: 言語ペアの対応状態を返す ─────────
+    // Apple の Translation framework が拡張プロセスから programmatic に呼べるかの最小検証。
+    // UI を伴わない LanguageAvailability API のみ使用する。
+    // payload: { source: "en", target: "ja" } / 結果: installed | supported | unsupported
+    @available(iOS 13.0, macOS 10.15, *)
+    private func handleCheckLanguageAvailability(payload: [String: Any]) async -> [String: Any] {
+        guard let source = payload["source"] as? String,
+              let target = payload["target"] as? String else {
+            return ["ok": false, "error": "missing source/target"]
+        }
+
+        // LanguageAvailability は iOS 18+ / macOS 15+ で programmatic に呼び出し可能。
+        // 17.4〜17.x / 14.4〜14.x は Translation framework は存在するが API は SwiftUI 経由のみ。
+        if #available(iOS 18.0, macOS 15.0, *) {
+            #if canImport(Translation)
+            let availability = LanguageAvailability()
+            let sourceLang = Locale.Language(identifier: source)
+            let targetLang = Locale.Language(identifier: target)
+            let status = await availability.status(from: sourceLang, to: targetLang)
+
+            let statusString: String
+            switch status {
+            case .installed: statusString = "installed"
+            case .supported: statusString = "supported"
+            case .unsupported: statusString = "unsupported"
+            @unknown default: statusString = "unknown"
+            }
+            return [
+                "ok": true,
+                "status": statusString,
+                "source": source,
+                "target": target,
+            ]
+            #else
+            return ["ok": false, "error": "Translation framework not importable"]
+            #endif
+        } else {
+            return ["ok": false, "error": "Requires iOS 18+ / macOS 15+ for programmatic LanguageAvailability"]
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

iOS / macOS Safari Web Extension で Apple `Translation` framework を使ったオンデバイス翻訳の実現可能性を検証する第1段階 PoC。
このPRは**ネイティブ側のみ**の変更で、JS 側の統合は次段階で行う。

## 変更点

`SafariWebExtensionHandler.swift` を action-base のディスパッチ構造に拡張：

| action | 用途 |
|---|---|
| `ping` | ブリッジ動作確認・OS と Translation framework の可否を返す |
| `checkLanguageAvailability` | `LanguageAvailability` で言語ペア対応状態（installed / supported / unsupported）を返す |
| その他 / action 無し | 旧 echo 動作（後方互換） |

## availability ガード

| API | 必要バージョン |
|---|---|
| `Task { ... }` | iOS 13+ / macOS 10.15+ |
| `import Translation` | iOS 17.4+ / macOS 14.4+ |
| `LanguageAvailability` programmatic 呼び出し | iOS 18+ / macOS 15+ |

deployment target（iOS 15.0 / macOS 10.14）はそのままにし、未対応 OS では機能無効レスポンスを返す。

## 検証

- macOS scheme: `xcodebuild ... build` → **BUILD SUCCEEDED**
- iOS scheme（Simulator generic destination）: **BUILD SUCCEEDED**

## 実機での確認依頼

このPRをマージ後、Xcode で実機にインストールしブラウザコンソールから以下を試してほしい：

```javascript
// Safari の拡張コンソールで
browser.runtime.sendNativeMessage("application.id", { action: "ping" })
  .then(r => console.log("ping:", r));

browser.runtime.sendNativeMessage("application.id", {
  action: "checkLanguageAvailability",
  source: "en",
  target: "ja"
}).then(r => console.log("availability:", r));
```

期待結果：
- `ping` → `{ ok: true, osVersion: "...", translationFrameworkAvailable: true, languageAvailabilityAPIAvailable: true }`（iOS 18+ / macOS 15+ の場合）
- `checkLanguageAvailability` → `{ ok: true, status: "installed" | "supported" | "unsupported", ... }`

これが返ってくれば「拡張プロセスから Translation framework が programmatic に呼べる」ことが確認できる。
返ってこない場合は次段階の hosting 戦略で対応を検討する。

## 次段階（このPRには含めない）

- 実翻訳エンドポイント（`TranslationSession` の hosting 戦略を試行）
- JS 側の `apple` エンジン統合（`background.js` ディスパッチャ・popup UI・i18n）
- 翻訳キャッシュ統合
- 自動テスト・手動テストシナリオ
- README / ストア掲載文の更新

## テスト

- 自動テスト: 影響なし（JS 側変更なし）。`npm test` 実行必要なし。
- 手動: 実機での `browser.runtime.sendNativeMessage` 動作確認（上記）

closes #144