### PR TITLE
feat: nativeMessaging 権限追加 + Locale.Language 構築修正 + 診断アクション（#146）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ package-lock.json
 # Xcode (Safari Web Extension project)
 safari/**/xcuserdata/
 safari/**/*.xcuserstate
-safari/build/
+safari/**/build/

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "permissions": [
     "activeTab",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "nativeMessaging"
   ],
   "host_permissions": [
     "https://translate.googleapis.com/*",

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -288,18 +288,4 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         }
     }
 
-    // ─── Locale.Language ヘルパー ─────────────────────────────────
-    // "en" / "ja" / "zh-CN" のような短い言語コードから Locale.Language を構築する。
-    // 単純な identifier 渡しだと script/region 解決の差異で対応判定が外れることがあるため、
-    // languageCode コンポーネント経由で構築する。
-    // Locale.Language 自体が iOS 16+ / macOS 13+ で導入された型のため availability ガード必須。
-    @available(iOS 16.0, macOS 13.0, *)
-    private func makeLanguage(from code: String) -> Locale.Language {
-        // ハイフンが含まれる場合（"zh-CN" 等）は identifier 渡しの方が region/script 推定が効く
-        if code.contains("-") || code.contains("_") {
-            return Locale.Language(identifier: code)
-        }
-        return Locale.Language(languageCode: Locale.LanguageCode(code))
-    }
-
 }

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -146,11 +146,14 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         if #available(iOS 18.0, macOS 15.0, *) {
             #if canImport(Translation)
             let availability = LanguageAvailability()
-            // Locale.Language(identifier:) は BCP-47 文字列をパースするが、"en" / "ja" のような
-            // 言語コードのみだと script / region が解決されず、フレームワークの対応リストとマッチせず
-            // unsupported になる場合がある。languageCode: で構築する方が堅牢。
-            let sourceLang = makeLanguage(from: source)
-            let targetLang = makeLanguage(from: target)
+            let supported = await availability.supportedLanguages
+
+            // 自前で Locale.Language を組み立てると script/region が nil のままになり、
+            // フレームワーク内部の components 照合で対応リストとマッチせず unsupported になる。
+            // 対応リストから該当言語コードを持つ Language を直接ピックして渡す。
+            // ハイフン入りコード（"zh-CN" 等）は region で絞り込み、それ以外は languageCode のみで一致を探す。
+            let sourceLang = resolveLanguage(code: source, from: supported)
+            let targetLang = resolveLanguage(code: target, from: supported)
             let status = await availability.status(from: sourceLang, to: targetLang)
 
             let statusString: String
@@ -165,9 +168,10 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 "status": statusString,
                 "source": source,
                 "target": target,
-                // 構築した Language の最大識別子もデバッグ用に返す（実際にどう解決されたかが分かる）
                 "sourceMaximalIdentifier": sourceLang.maximalIdentifier,
                 "targetMaximalIdentifier": targetLang.maximalIdentifier,
+                "sourceMatchedFromSupported": isInSupported(sourceLang, supported: supported),
+                "targetMatchedFromSupported": isInSupported(targetLang, supported: supported),
             ]
             #else
             return ["ok": false, "error": "Translation framework not importable"]
@@ -175,6 +179,36 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         } else {
             return ["ok": false, "error": "Requires iOS 18+ / macOS 15+ for programmatic LanguageAvailability"]
         }
+    }
+
+    // 対応リストから入力コードに合う Locale.Language を選ぶ。
+    // 完全一致が無ければ、新規構築した Language をフォールバックとして返す。
+    @available(iOS 16.0, macOS 13.0, *)
+    private func resolveLanguage(code: String, from supported: [Locale.Language]) -> Locale.Language {
+        // "zh-CN" 形式: region を比較
+        if code.contains("-") || code.contains("_") {
+            let parts = code.replacingOccurrences(of: "_", with: "-").split(separator: "-")
+            if parts.count >= 2 {
+                let langPart = String(parts[0])
+                let regionPart = String(parts[1]).uppercased()
+                if let match = supported.first(where: {
+                    $0.languageCode?.identifier == langPart && $0.region?.identifier == regionPart
+                }) {
+                    return match
+                }
+            }
+            return Locale.Language(identifier: code)
+        }
+        // 言語コードのみ（"en" / "ja"）: languageCode 一致の最初のエントリを採用
+        if let match = supported.first(where: { $0.languageCode?.identifier == code }) {
+            return match
+        }
+        return Locale.Language(languageCode: Locale.LanguageCode(code))
+    }
+
+    @available(iOS 16.0, macOS 13.0, *)
+    private func isInSupported(_ lang: Locale.Language, supported: [Locale.Language]) -> Bool {
+        return supported.contains(where: { $0.maximalIdentifier == lang.maximalIdentifier })
     }
 
     // ─── listSupportedLanguages: 対応言語リストを返す ────────────────

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -64,6 +64,22 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                     ])
                 }
                 return
+            case "listSupportedLanguages":
+                // 対応言語リストを返す診断用アクション。
+                // checkLanguageAvailability が unsupported を返す場合に、
+                // フレームワークが期待する identifier 形式を確認するために使用する。
+                if #available(iOS 13.0, macOS 10.15, *) {
+                    Task {
+                        let body = await handleListSupportedLanguages()
+                        respond(context: context, body: body)
+                    }
+                } else {
+                    respond(context: context, body: [
+                        "ok": false,
+                        "error": "Requires iOS 13+ / macOS 10.15+ runtime"
+                    ])
+                }
+                return
             default:
                 // 未知の action は明示的にエラーを返す（黙って echo にフォールバックすると
                 // JS 側のバグに気付きにくくなるため）
@@ -130,8 +146,11 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         if #available(iOS 18.0, macOS 15.0, *) {
             #if canImport(Translation)
             let availability = LanguageAvailability()
-            let sourceLang = Locale.Language(identifier: source)
-            let targetLang = Locale.Language(identifier: target)
+            // Locale.Language(identifier:) は BCP-47 文字列をパースするが、"en" / "ja" のような
+            // 言語コードのみだと script / region が解決されず、フレームワークの対応リストとマッチせず
+            // unsupported になる場合がある。languageCode: で構築する方が堅牢。
+            let sourceLang = makeLanguage(from: source)
+            let targetLang = makeLanguage(from: target)
             let status = await availability.status(from: sourceLang, to: targetLang)
 
             let statusString: String
@@ -146,6 +165,9 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 "status": statusString,
                 "source": source,
                 "target": target,
+                // 構築した Language の最大識別子もデバッグ用に返す（実際にどう解決されたかが分かる）
+                "sourceMaximalIdentifier": sourceLang.maximalIdentifier,
+                "targetMaximalIdentifier": targetLang.maximalIdentifier,
             ]
             #else
             return ["ok": false, "error": "Translation framework not importable"]
@@ -153,6 +175,51 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         } else {
             return ["ok": false, "error": "Requires iOS 18+ / macOS 15+ for programmatic LanguageAvailability"]
         }
+    }
+
+    // ─── listSupportedLanguages: 対応言語リストを返す ────────────────
+    // フレームワークが認識する識別子の正確な形式を確認するための診断用アクション。
+    // checkLanguageAvailability が想定外に unsupported を返す場合の切り分けに使う。
+    @available(iOS 13.0, macOS 10.15, *)
+    private func handleListSupportedLanguages() async -> [String: Any] {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            #if canImport(Translation)
+            let availability = LanguageAvailability()
+            let supported = await availability.supportedLanguages
+            // 各 Language を maximalIdentifier（"en-Latn-US" 形式）と内部コンポーネントで返す
+            let entries: [[String: String]] = supported.map { lang in
+                [
+                    "maximalIdentifier": lang.maximalIdentifier,
+                    "languageCode": lang.languageCode?.identifier ?? "",
+                    "script": lang.script?.identifier ?? "",
+                    "region": lang.region?.identifier ?? "",
+                ]
+            }
+            return [
+                "ok": true,
+                "count": entries.count,
+                "languages": entries,
+            ]
+            #else
+            return ["ok": false, "error": "Translation framework not importable"]
+            #endif
+        } else {
+            return ["ok": false, "error": "Requires iOS 18+ / macOS 15+ for programmatic LanguageAvailability"]
+        }
+    }
+
+    // ─── Locale.Language ヘルパー ─────────────────────────────────
+    // "en" / "ja" / "zh-CN" のような短い言語コードから Locale.Language を構築する。
+    // 単純な identifier 渡しだと script/region 解決の差異で対応判定が外れることがあるため、
+    // languageCode コンポーネント経由で構築する。
+    // Locale.Language 自体が iOS 16+ / macOS 13+ で導入された型のため availability ガード必須。
+    @available(iOS 16.0, macOS 13.0, *)
+    private func makeLanguage(from code: String) -> Locale.Language {
+        // ハイフンが含まれる場合（"zh-CN" 等）は identifier 渡しの方が region/script 推定が効く
+        if code.contains("-") || code.contains("_") {
+            return Locale.Language(identifier: code)
+        }
+        return Locale.Language(languageCode: Locale.LanguageCode(code))
     }
 
 }

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -148,16 +148,39 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             let availability = LanguageAvailability()
             let supported = await availability.supportedLanguages
 
-            // 自前で Locale.Language を組み立てると script/region が nil のままになり、
-            // フレームワーク内部の components 照合で対応リストとマッチせず unsupported になる。
-            // 対応リストから該当言語コードを持つ Language を直接ピックして渡す。
-            // ハイフン入りコード（"zh-CN" 等）は region で絞り込み、それ以外は languageCode のみで一致を探す。
-            let sourceLang = resolveLanguage(code: source, from: supported)
-            let targetLang = resolveLanguage(code: target, from: supported)
-            let status = await availability.status(from: sourceLang, to: targetLang)
+            // フレームワークの status(from:to:) は region 単位で対応判定するため、
+            // 同じ言語コードでも en-IN→ja-JP は未対応・en-US→ja-JP は対応のように分岐する。
+            // 入力コード（"en" 等）に該当する全リージョン variant を取得し、preferred 順に
+            // 全ペア組み合わせを試して installed/supported が返る最初のペアを採用する。
+            let sourceCandidates = candidateLanguages(code: source, from: supported)
+            let targetCandidates = candidateLanguages(code: target, from: supported)
+
+            var bestStatus: LanguageAvailability.Status = .unsupported
+            var bestSource = sourceCandidates.first ?? Locale.Language(identifier: source)
+            var bestTarget = targetCandidates.first ?? Locale.Language(identifier: target)
+            var foundSupported = false
+
+            outer: for src in sourceCandidates {
+                for tgt in targetCandidates {
+                    let s = await availability.status(from: src, to: tgt)
+                    // 最初に試したペアを暫定として保持（全ペア unsupported のときの返却用）
+                    if !foundSupported && bestStatus == .unsupported {
+                        bestStatus = s
+                        bestSource = src
+                        bestTarget = tgt
+                    }
+                    if s == .installed || s == .supported {
+                        bestStatus = s
+                        bestSource = src
+                        bestTarget = tgt
+                        foundSupported = true
+                        break outer
+                    }
+                }
+            }
 
             let statusString: String
-            switch status {
+            switch bestStatus {
             case .installed: statusString = "installed"
             case .supported: statusString = "supported"
             case .unsupported: statusString = "unsupported"
@@ -168,10 +191,10 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 "status": statusString,
                 "source": source,
                 "target": target,
-                "sourceMaximalIdentifier": sourceLang.maximalIdentifier,
-                "targetMaximalIdentifier": targetLang.maximalIdentifier,
-                "sourceMatchedFromSupported": isInSupported(sourceLang, supported: supported),
-                "targetMatchedFromSupported": isInSupported(targetLang, supported: supported),
+                "sourceMaximalIdentifier": bestSource.maximalIdentifier,
+                "targetMaximalIdentifier": bestTarget.maximalIdentifier,
+                "sourceCandidatesCount": sourceCandidates.count,
+                "targetCandidatesCount": targetCandidates.count,
             ]
             #else
             return ["ok": false, "error": "Translation framework not importable"]
@@ -181,11 +204,11 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         }
     }
 
-    // 対応リストから入力コードに合う Locale.Language を選ぶ。
-    // 完全一致が無ければ、新規構築した Language をフォールバックとして返す。
+    // 入力コードに対応する Locale.Language の候補リストを preferred region 順で返す。
+    // 主要言語は実用的な region を優先順位付きで列挙する。それ以外は対応リストの登録順。
     @available(iOS 16.0, macOS 13.0, *)
-    private func resolveLanguage(code: String, from supported: [Locale.Language]) -> Locale.Language {
-        // "zh-CN" 形式: region を比較
+    private func candidateLanguages(code: String, from supported: [Locale.Language]) -> [Locale.Language] {
+        // "zh-CN" 形式: region 完全一致のみを返す（曖昧さを残さない）
         if code.contains("-") || code.contains("_") {
             let parts = code.replacingOccurrences(of: "_", with: "-").split(separator: "-")
             if parts.count >= 2 {
@@ -194,21 +217,44 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 if let match = supported.first(where: {
                     $0.languageCode?.identifier == langPart && $0.region?.identifier == regionPart
                 }) {
-                    return match
+                    return [match]
                 }
             }
-            return Locale.Language(identifier: code)
+            return [Locale.Language(identifier: code)]
         }
-        // 言語コードのみ（"en" / "ja"）: languageCode 一致の最初のエントリを採用
-        if let match = supported.first(where: { $0.languageCode?.identifier == code }) {
-            return match
+
+        // 言語コードのみ: languageCode 一致を全て取得し、preferred region 順にソート
+        let matches = supported.filter { $0.languageCode?.identifier == code }
+        if matches.isEmpty {
+            return [Locale.Language(languageCode: Locale.LanguageCode(code))]
         }
-        return Locale.Language(languageCode: Locale.LanguageCode(code))
+
+        // 主要言語の preferred region 優先順位（先頭ほど高優先）
+        let preferred: [String] = preferredRegions(for: code)
+        return matches.sorted { a, b in
+            let aRegion = a.region?.identifier ?? ""
+            let bRegion = b.region?.identifier ?? ""
+            let aIdx = preferred.firstIndex(of: aRegion) ?? Int.max
+            let bIdx = preferred.firstIndex(of: bRegion) ?? Int.max
+            return aIdx < bIdx
+        }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
-    private func isInSupported(_ lang: Locale.Language, supported: [Locale.Language]) -> Bool {
-        return supported.contains(where: { $0.maximalIdentifier == lang.maximalIdentifier })
+    private func preferredRegions(for code: String) -> [String] {
+        switch code {
+        case "en": return ["US", "GB", "AU", "CA", "IE", "NZ", "SG", "ZA", "IN"]
+        case "ja": return ["JP"]
+        case "ko": return ["KR"]
+        case "zh": return ["CN", "TW", "HK"]
+        case "fr": return ["FR", "CA"]
+        case "de": return ["DE", "CH"]
+        case "es": return ["ES", "MX", "US"]
+        case "pt": return ["PT", "BR"]
+        case "it": return ["IT", "CH"]
+        case "ar": return ["AE"]
+        case "ru": return ["RU"]
+        default: return []
+        }
     }
 
     // ─── listSupportedLanguages: 対応言語リストを返す ────────────────


### PR DESCRIPTION
## Summary

Issue #144 の Apple Translation framework 連携 PoC を実機検証する過程で発見した問題に対処：

1. `manifest.json` に `nativeMessaging` 権限が無く `browser.runtime.sendNativeMessage` が undefined
2. `Locale.Language(identifier: "en")` 構築で Translation framework の対応リストとマッチせず `unsupported` 誤判定
3. region 単位での対応判定（en-IN→ja-JP は未対応・en-US→ja-JP は対応のように分岐する）

## 変更点

### 1. manifest.json
`permissions` に `"nativeMessaging"` 追加。

### 2. SafariWebExtensionHandler.swift
- 診断用 **`listSupportedLanguages` アクション**追加
- `checkLanguageAvailability` を、**`supportedLanguages` から Language を直接ピックして preferred region 順に全ペア試行**する方式に変更
- レスポンスに `sourceMaximalIdentifier` / `targetMaximalIdentifier` / `sourceCandidatesCount` / `targetCandidatesCount` を追加（診断用）

## 検証結果

### macOS Safari（成功 ✅）

| ペア | source | target | status |
|---|---|---|---|
| en→es | en-Latn-US | es-Latn-ES | **installed** |
| en→fr | en-Latn-US | fr-Latn-FR | **installed** |
| ja→en | ja-Jpan-JP | en-Latn-US | **installed** |

→ Translation framework が拡張プロセスから programmatic に呼び出し可能なことを実証。

### iOS Simulator（既知制限 ⚠️）

iOS Simulator では `LanguageAvailability.status()` が**全ペア `unsupported` を返す**。これは Apple の On-Device ML 系 API（Vision / Speech / Foundation Models 等）が Simulator で機能制限される既知パターンと一致。**実機 iPhone / iPad での再検証が必要**だが、本 PR のスコープ外（次段階）。

### 自動テスト

- `npm test`: 440/440 passed
- Xcode build (iOS Simulator): BUILD SUCCEEDED
- Xcode build (macOS): BUILD SUCCEEDED

## ブラウザ別の影響（manifest 権限追加）

| ブラウザ | 影響 |
|---|---|
| Safari (iOS/macOS) | `sendNativeMessage` 利用可。Translation framework 連携の前提 |
| Chrome | 権限宣言のみ。Native Messaging Host 未登録のため実呼び出しは失敗（無害） |
| Firefox | 同上 |

## ストア審査について

権限追加で Chrome / Firefox ストア再審査の可能性あり。リリース時に掲載文へ「Safari でのオンデバイス翻訳連携用」追記が必要（リリース PR で対応）。

## 次段階

実テキスト翻訳には `TranslationSession`（SwiftUI 必須）が必要。NSHostingController による隠しホスト戦略を別 Issue で検証する。

closes #146