### PR TITLE
feat: 隠し SwiftUI ホスト経由で translate アクションを実装（macOS PoC, #148）

### DIFF
--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -6,12 +6,16 @@
 //
 
 import SafariServices
+import SwiftUI
 import os.log
 // Translation framework は iOS 17.4+ / macOS 14.4+ にしか存在しないため、
 // strong link すると iOS 15 / macOS 10.14 など古い OS で dyld が拡張をロードできなくなる。
 // @_weakLinked により実体不在時もロードを許可し、availability ガードで実呼び出しを抑止する。
 #if canImport(Translation)
 @_weakLinked import Translation
+#endif
+#if os(macOS)
+import AppKit
 #endif
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
@@ -77,6 +81,22 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                     respond(context: context, body: [
                         "ok": false,
                         "error": "Requires iOS 13+ / macOS 10.15+ runtime"
+                    ])
+                }
+                return
+            case "translate":
+                // 実テキスト翻訳。TranslationSession は SwiftUI 経由でしか取得できないため、
+                // NSHostingController + 画面外 NSWindow で隠し SwiftUI ビューをホストする戦略。
+                // macOS のみ対応。iOS 拡張プロセスは UIWindowScene 非保有のため別途検討。
+                if #available(iOS 18.0, macOS 15.0, *) {
+                    Task {
+                        let body = await handleTranslate(payload: payload ?? [:])
+                        respond(context: context, body: body)
+                    }
+                } else {
+                    respond(context: context, body: [
+                        "ok": false,
+                        "error": "Requires iOS 18+ / macOS 15+"
                     ])
                 }
                 return
@@ -288,4 +308,178 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         }
     }
 
+    // ─── translate: 実テキスト翻訳 ────────────────────────────────
+    // payload: { source, target, text }
+    // 戻り値: { ok: true, translated, sourceMaximalIdentifier, targetMaximalIdentifier }
+    //   or  { ok: false, error }
+    @available(iOS 18.0, macOS 15.0, *)
+    private func handleTranslate(payload: [String: Any]) async -> [String: Any] {
+        guard let source = payload["source"] as? String,
+              let target = payload["target"] as? String,
+              let text = payload["text"] as? String else {
+            return ["ok": false, "error": "missing source/target/text"]
+        }
+        if text.isEmpty {
+            return ["ok": true, "translated": ""]
+        }
+
+        #if canImport(Translation)
+        // 言語ペアを supportedLanguages から解決する（PR #147 のロジック流用）
+        let availability = LanguageAvailability()
+        let supported = await availability.supportedLanguages
+        let sourceCandidates = candidateLanguages(code: source, from: supported)
+        let targetCandidates = candidateLanguages(code: target, from: supported)
+        guard let sourceLang = sourceCandidates.first else {
+            return ["ok": false, "error": "source language not in supportedLanguages: \(source)"]
+        }
+        guard let targetLang = targetCandidates.first else {
+            return ["ok": false, "error": "target language not in supportedLanguages: \(target)"]
+        }
+
+        #if os(macOS)
+        do {
+            let translated = try await translateUsingHiddenHost_macOS(
+                text: text,
+                source: sourceLang,
+                target: targetLang
+            )
+            return [
+                "ok": true,
+                "translated": translated,
+                "sourceMaximalIdentifier": sourceLang.maximalIdentifier,
+                "targetMaximalIdentifier": targetLang.maximalIdentifier,
+            ]
+        } catch {
+            return [
+                "ok": false,
+                "error": "translation failed: \(error.localizedDescription)",
+            ]
+        }
+        #else
+        // iOS の Safari Web Extension ハンドラは UIWindowScene を持たないため、
+        // SwiftUI ホスト戦略は使えない。別途 App Group 経由などの戦略が必要（次段階）。
+        return [
+            "ok": false,
+            "error": "iOS translation not yet implemented (requires App Group bridge to container app)",
+        ]
+        #endif
+        #else
+        return ["ok": false, "error": "Translation framework not importable"]
+        #endif
+    }
+
+    #if os(macOS) && canImport(Translation)
+    // SwiftUI 経由で TranslationSession を取得して翻訳実行する。
+    // 画面外の NSWindow に NSHostingController を置き、ビューが「appear」したタイミングで
+    // .translationTask の closure に渡される TranslationSession を使う。
+    // CheckedContinuation で結果を非同期に受け取る。Window と HostingController は
+    // Holder クラスで継続中強参照を保持し、結果コールバック後に解放する。
+    @available(macOS 15.0, *)
+    @MainActor
+    private func translateUsingHiddenHost_macOS(
+        text: String,
+        source: Locale.Language,
+        target: Locale.Language
+    ) async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            let holder = HiddenHostHolder()
+            // タイムアウト保険: 30 秒以内に結果が来なかった場合は強制終了する
+            let timeoutTask = Task { [weak holder] in
+                try? await Task.sleep(nanoseconds: 30_000_000_000)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    if holder?.window != nil {
+                        holder?.cleanup()
+                        continuation.resume(throwing: NSError(
+                            domain: "DVT.Translation",
+                            code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "translation timed out (30s)"]
+                        ))
+                    }
+                }
+            }
+
+            let view = TranslationHostView(
+                text: text,
+                source: source,
+                target: target
+            ) { result in
+                // 結果が一度確定したら timeout を停止して window/hosting を解放
+                timeoutTask.cancel()
+                holder.cleanup()
+                continuation.resume(with: result)
+            }
+
+            let hosting = NSHostingController(rootView: view)
+            // 画面外（負座標）かつ alphaValue=0 で実質不可視のウィンドウを作る。
+            // borderless スタイルでメニューバー等の干渉も回避。
+            let window = NSWindow(
+                contentRect: NSRect(x: -10000, y: -10000, width: 1, height: 1),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentViewController = hosting
+            window.alphaValue = 0
+            window.ignoresMouseEvents = true
+            // orderFrontRegardless で実際にビューが appear するまで進める
+            window.orderFrontRegardless()
+
+            holder.window = window
+            holder.hostingController = hosting
+        }
+    }
+    #endif
 }
+
+#if os(macOS) && canImport(Translation)
+// 隠しホスト関連のリソースを retain/release するためのクラス。
+// 値型のローカル変数では非同期境界を超えられないため class でくるむ。
+@available(macOS 15.0, *)
+@MainActor
+private final class HiddenHostHolder {
+    var window: NSWindow?
+    var hostingController: NSHostingController<TranslationHostView>?
+
+    func cleanup() {
+        window?.orderOut(nil)
+        window?.contentViewController = nil
+        window = nil
+        hostingController = nil
+    }
+}
+
+// 隠しホスト用の最小 SwiftUI ビュー。
+// configuration を State で持ち、ビューが appear した瞬間に .translationTask が起動して
+// session.translate(text) を実行、結果を onResult で外に返す。
+@available(iOS 18.0, macOS 15.0, *)
+private struct TranslationHostView: View {
+    let text: String
+    @State private var configuration: TranslationSession.Configuration?
+    let onResult: (Result<String, Error>) -> Void
+
+    init(
+        text: String,
+        source: Locale.Language,
+        target: Locale.Language,
+        onResult: @escaping (Result<String, Error>) -> Void
+    ) {
+        self.text = text
+        self.onResult = onResult
+        _configuration = State(initialValue: TranslationSession.Configuration(source: source, target: target))
+    }
+
+    var body: some View {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .translationTask(configuration) { session in
+                do {
+                    let response = try await session.translate(text)
+                    onResult(.success(response.targetText))
+                } catch {
+                    onResult(.failure(error))
+                }
+            }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Issue #148 第2段階。Apple `Translation` framework での実テキスト翻訳エンドポイントを Safari Web Extension のネイティブハンドラに追加。

## アプローチ

`TranslationSession` は SwiftUI の `.translationTask(_:action:)` modifier 経由でしか取得できない API なので、拡張プロセス内に **画面外の隠し SwiftUI ビューをホスト**して取得する戦略。

- `TranslationHostView`: 1pt の `Color.clear` に `.translationTask` を貼り、appear 時に `session.translate(text)` を実行して結果を `Result` でコールバック
- `translateUsingHiddenHost_macOS`: 画面外 (-10000, -10000) / alphaValue=0 / borderless の `NSWindow` に `NSHostingController` でビューを置き、`orderFrontRegardless` で appear をトリガ
- `CheckedContinuation` で async ブリッジ
- `HiddenHostHolder` で `NSWindow` / `NSHostingController` を継続中強参照保持、結果コールバック後に明示クリーンアップ
- 30 秒タイムアウト保険

## API

### Request
```javascript
browser.runtime.sendNativeMessage("jp.co.orangesoft.dualview-translator", {
  action: "translate",
  source: "en",
  target: "ja",
  text: "Hello, world!"
}).then(r => console.log(r));
```

### Response
```javascript
{
  ok: true,
  translated: "こんにちは、世界！",
  sourceMaximalIdentifier: "en-Latn-US",
  targetMaximalIdentifier: "ja-Jpan-JP"
}
```

## プラットフォーム対応

| プラットフォーム | 状態 |
|---|---|
| macOS Safari | 本 PR で対応 |
| iOS Safari | **未対応**（拡張プロセスが `UIWindowScene` 非保有のため SwiftUI ホスト戦略不可）。別 PR で App Group 経由方式を検討 |

## 検証

- `npm test`: 440/440 passed
- Xcode build (macOS): BUILD SUCCEEDED
- Xcode build (iOS Simulator): BUILD SUCCEEDED

## マージ後の動作確認

macOS Safari に拡張を再インストール → background script の Web Inspector で：

```javascript
browser.runtime.sendNativeMessage("jp.co.orangesoft.dualview-translator", {
  action: "translate",
  source: "en",
  target: "ja",
  text: "Hello, world!"
}).then(r => console.log(r));
```

期待値: `{ ok: true, translated: "..." }`（日本語訳された文字列）

`{ ok: false, error: "..." }` が返る場合は、エラーメッセージで原因を特定する：
- `"translation timed out (30s)"` → ビューが appear しなかった可能性。NSWindow 戦略が拡張プロセスで動かない
- `"translation failed: ..."` → TranslationSession 自体は取れたが翻訳実行で失敗
- `"... not in supportedLanguages"` → 言語ペア未対応

## 次段階

- iOS 用 App Group + コンテナアプリ橋渡し方式（別 Issue）
- JS 側統合（`apple` エンジン追加、popup UI、i18n、キャッシュ統合）

closes #148