### PR TITLE
feat: オフライン時に Google/DeepL 選択中でも Apple Translation に自動フォールバック（#150）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ content-*.js → chrome.runtime.sendMessage → background.js → Google Transla
 - **Apple Translation**（Safari 限定・macOS）: `chrome.runtime.sendNativeMessage` で `SafariWebExtensionHandler` の `translate` アクションを呼び、On-Device の `Translation.framework` で翻訳。ネットワーク・APIキー不要
 - 切り替え: `chrome.storage.local` の `translateEngine` / `deeplApiKey` で管理
 - Safari 検出: 拡張起動時に `ping` を投げて応答有無で判定し、`chrome.storage.local.appleAvailable` にキャッシュ。popup の `<option value="apple">` は `appleAvailable: true` のときだけ表示される
+- **オフラインフォールバック**: `fetchTranslation` ディスパッチャは Google / DeepL 選択時でも、`navigator.onLine === false` または fetch の network error 発生時に Apple Translation へ自動フォールバックする（`appleAvailable` && `sl !== 'auto'` のみ）。`fetchTranslation` の戻り値に `engineUsed` / `fallback` / `fallbackReason` を含めて UI 側で識別可能にしている
 
 ### 翻訳・要約キャッシュ
 

--- a/background.js
+++ b/background.js
@@ -388,10 +388,13 @@ async function getCacheStats() {
 // fetch がネットワーク不通で失敗した場合は TypeError("Failed to fetch") 等を throw する。
 // HTTP エラー (4xx/5xx) は別 throw で識別可能なので除外。
 // このヘルパーで「オフラインフォールバックが妥当か」を判定する。
+//
+// TypeError 単独だと fetch 以外のコードバグ（プロパティ参照ミス等）も誤検知して
+// バグを apple フォールバックで隠蔽してしまうため、TypeError + ネットワーク系
+// メッセージの両方を要求する。
 function isNetworkError(err) {
   if (!err) return false;
-  // fetch の TypeError は環境によりメッセージが異なる: "Failed to fetch" / "Network request failed" / "Load failed" 等
-  if (err.name === 'TypeError') return true;
+  if (!(err instanceof TypeError) && err.name !== 'TypeError') return false;
   const msg = (err.message || '').toLowerCase();
   return msg.includes('failed to fetch') ||
     msg.includes('network') ||
@@ -465,9 +468,12 @@ async function fetchTranslation(text, tl, sl, config) {
     }
   }
 
-  // 主エンジン実行（network error は apple フォールバック対象）
+  // 主エンジン実行（network error は apple フォールバック対象）。
+  // config.engine='deepl' でも APIキー未設定なら Google にフォールスルーするため、
+  // 実際に呼ばれたエンジンを primaryEngine として保持し、ログ・engineUsed の出力を一致させる。
+  const primaryEngine = (config.engine === 'deepl' && config.deeplApiKey) ? 'deepl' : 'google';
   try {
-    if (config.engine === 'deepl' && config.deeplApiKey) {
+    if (primaryEngine === 'deepl') {
       const result = await fetchDeepL(text, tl, sl, config.deeplApiKey);
       return { ...result, engineUsed: 'deepl' };
     }
@@ -475,7 +481,7 @@ async function fetchTranslation(text, tl, sl, config) {
     return { ...result, engineUsed: 'google' };
   } catch (err) {
     if (config.appleAvailable && isNetworkError(err)) {
-      console.warn(`[DVT] ${config.engine} network error → apple fallback:`, err.message);
+      console.warn(`[DVT] ${primaryEngine} network error → apple fallback:`, err.message);
       const finalSl = await ensureExplicitSourceLang(sl, text);
       const result = await fetchApple(text, tl, finalSl);
       return { ...result, engineUsed: 'apple', fallback: true, fallbackReason: 'network-error' };

--- a/background.js
+++ b/background.js
@@ -384,17 +384,65 @@ async function getCacheStats() {
   };
 }
 
-// ─── 翻訳ディスパッチャー ────────────────────────────────────────────
-async function fetchTranslation(text, tl, sl, config) {
-  if (!text || !text.trim()) return { text: '', detectedLang: null };
+// ─── ネットワークエラー判定 ──────────────────────────────────────────
+// fetch がネットワーク不通で失敗した場合は TypeError("Failed to fetch") 等を throw する。
+// HTTP エラー (4xx/5xx) は別 throw で識別可能なので除外。
+// このヘルパーで「オフラインフォールバックが妥当か」を判定する。
+function isNetworkError(err) {
+  if (!err) return false;
+  // fetch の TypeError は環境によりメッセージが異なる: "Failed to fetch" / "Network request failed" / "Load failed" 等
+  if (err.name === 'TypeError') return true;
+  const msg = (err.message || '').toLowerCase();
+  return msg.includes('failed to fetch') ||
+    msg.includes('network') ||
+    msg.includes('load failed') ||
+    msg.includes('offline');
+}
 
+// ─── 翻訳ディスパッチャー ────────────────────────────────────────────
+// オフラインフォールバック動作:
+// - apple が明示選択されていればそのまま fetchApple
+// - 起動時に navigator.onLine === false を検出していれば、apple 利用可能なら apple にフォールバック
+// - 主エンジン実行中に network error が発生した場合も apple にフォールバック
+// - sl === 'auto' は apple が auto 検出を提供しないためフォールバックしない（誤訳回避）
+async function fetchTranslation(text, tl, sl, config) {
+  if (!text || !text.trim()) return { text: '', detectedLang: null, engineUsed: null };
+
+  // 明示選択された apple は直行
   if (config.engine === 'apple' && config.appleAvailable) {
-    return fetchApple(text, tl, sl);
+    const result = await fetchApple(text, tl, sl);
+    return { ...result, engineUsed: 'apple' };
   }
-  if (config.engine === 'deepl' && config.deeplApiKey) {
-    return fetchDeepL(text, tl, sl, config.deeplApiKey);
+
+  const canFallbackToApple = config.appleAvailable && sl && sl !== 'auto';
+
+  // 起動時オフライン: 主エンジンが必ず失敗するので最初から apple を試す
+  if (typeof navigator !== 'undefined' && navigator.onLine === false && canFallbackToApple) {
+    try {
+      const result = await fetchApple(text, tl, sl);
+      return { ...result, engineUsed: 'apple', fallback: true, fallbackReason: 'offline' };
+    } catch (e) {
+      // apple も失敗したら主エンジンを試す（一応）。ここで投げ直さず継続
+      console.warn('[DVT] offline → apple fallback failed, trying primary engine:', e.message);
+    }
   }
-  return fetchGoogle(text, tl, sl);
+
+  // 主エンジン実行（network error は apple フォールバック対象）
+  try {
+    if (config.engine === 'deepl' && config.deeplApiKey) {
+      const result = await fetchDeepL(text, tl, sl, config.deeplApiKey);
+      return { ...result, engineUsed: 'deepl' };
+    }
+    const result = await fetchGoogle(text, tl, sl);
+    return { ...result, engineUsed: 'google' };
+  } catch (err) {
+    if (canFallbackToApple && isNetworkError(err)) {
+      console.warn(`[DVT] ${config.engine} network error → apple fallback:`, err.message);
+      const result = await fetchApple(text, tl, sl);
+      return { ...result, engineUsed: 'apple', fallback: true, fallbackReason: 'network-error' };
+    }
+    throw err;
+  }
 }
 
 // ─── Google Translate ────────────────────────────────────────────────

--- a/background.js
+++ b/background.js
@@ -399,27 +399,65 @@ function isNetworkError(err) {
     msg.includes('offline');
 }
 
+// NLLanguage 形式（"zh-Hans" / "zh-Hant"）→ アプリ内言語コード（"zh-CN" / "zh-TW"）への対応。
+// 他の言語は NLLanguage の rawValue がそのまま BCP-47 言語コードと一致するためマッピング不要。
+const NL_LANG_TO_APP = {
+  'zh-Hans': 'zh-CN',
+  'zh-Hant': 'zh-TW',
+};
+
+// SafariWebExtensionHandler の detectLanguage アクションを叩いて、
+// オフラインで言語検出する（NLLanguageRecognizer 経由）。
+// 失敗したら null を返し、呼び出し元で適切にエラー化する。
+async function detectLanguageNative(text) {
+  if (!HAS_NATIVE_MESSAGING) return null;
+  try {
+    const sample = text.slice(0, 500);
+    const response = await chrome.runtime.sendNativeMessage(NATIVE_HOST_ID, {
+      action: 'detectLanguage',
+      text: sample,
+    });
+    if (!response?.ok || !response.detectedLang) return null;
+    const code = response.detectedLang;
+    return NL_LANG_TO_APP[code] || code;
+  } catch (_e) {
+    return null;
+  }
+}
+
+// Apple Translation 呼び出し前に sl を必ず具体コードに解決する。
+// すでに具体コードならそのまま、auto / und / 空 ならネイティブ言語検出を経由する。
+async function ensureExplicitSourceLang(sl, text) {
+  if (sl && sl !== 'auto' && sl !== 'und') return sl;
+  const detected = await detectLanguageNative(text);
+  if (!detected) {
+    throw new Error('Apple Translation: language detection failed (offline)');
+  }
+  return detected;
+}
+
 // ─── 翻訳ディスパッチャー ────────────────────────────────────────────
 // オフラインフォールバック動作:
-// - apple が明示選択されていればそのまま fetchApple
+// - apple が明示選択されていればそのまま fetchApple（sl が auto なら native 検出で解決）
 // - 起動時に navigator.onLine === false を検出していれば、apple 利用可能なら apple にフォールバック
 // - 主エンジン実行中に network error が発生した場合も apple にフォールバック
-// - sl === 'auto' は apple が auto 検出を提供しないためフォールバックしない（誤訳回避）
+// - sl が auto/未指定でも NLLanguageRecognizer でオフライン検出するため、フォールバックは
+//   主要言語に対しては問題なく動作する（ただし検出失敗時はエラー）
 async function fetchTranslation(text, tl, sl, config) {
   if (!text || !text.trim()) return { text: '', detectedLang: null, engineUsed: null };
 
-  // 明示選択された apple は直行
+  // 明示選択された apple は直行（sl が auto なら native 検出で具体コードに解決）
   if (config.engine === 'apple' && config.appleAvailable) {
-    const result = await fetchApple(text, tl, sl);
+    const finalSl = await ensureExplicitSourceLang(sl, text);
+    const result = await fetchApple(text, tl, finalSl);
     return { ...result, engineUsed: 'apple' };
   }
 
-  const canFallbackToApple = config.appleAvailable && sl && sl !== 'auto';
-
   // 起動時オフライン: 主エンジンが必ず失敗するので最初から apple を試す
-  if (typeof navigator !== 'undefined' && navigator.onLine === false && canFallbackToApple) {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false && config.appleAvailable) {
     try {
-      const result = await fetchApple(text, tl, sl);
+      const finalSl = await ensureExplicitSourceLang(sl, text);
+      const result = await fetchApple(text, tl, finalSl);
       return { ...result, engineUsed: 'apple', fallback: true, fallbackReason: 'offline' };
     } catch (e) {
       // apple も失敗したら主エンジンを試す（一応）。ここで投げ直さず継続
@@ -436,9 +474,10 @@ async function fetchTranslation(text, tl, sl, config) {
     const result = await fetchGoogle(text, tl, sl);
     return { ...result, engineUsed: 'google' };
   } catch (err) {
-    if (canFallbackToApple && isNetworkError(err)) {
+    if (config.appleAvailable && isNetworkError(err)) {
       console.warn(`[DVT] ${config.engine} network error → apple fallback:`, err.message);
-      const result = await fetchApple(text, tl, sl);
+      const finalSl = await ensureExplicitSourceLang(sl, text);
+      const result = await fetchApple(text, tl, finalSl);
       return { ...result, engineUsed: 'apple', fallback: true, fallbackReason: 'network-error' };
     }
     throw err;

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -17,6 +17,9 @@ import os.log
 #if os(macOS)
 import AppKit
 #endif
+// NaturalLanguage は iOS 12+ / macOS 10.14+ で標準提供。
+// オフラインで言語検出可能な NLLanguageRecognizer をオフラインフォールバック時に利用する。
+import NaturalLanguage
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
@@ -99,6 +102,11 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                         "error": "Requires iOS 18+ / macOS 15+"
                     ])
                 }
+                return
+            case "detectLanguage":
+                // NLLanguageRecognizer によるオフライン言語検出。
+                // iOS 12+ / macOS 10.14+ で同期 API なので Task 不要・即応答。
+                respond(context: context, body: handleDetectLanguage(payload: payload ?? [:]))
                 return
             default:
                 // 未知の action は明示的にエラーを返す（黙って echo にフォールバックすると
@@ -306,6 +314,29 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         } else {
             return ["ok": false, "error": "Requires iOS 18+ / macOS 15+ for programmatic LanguageAvailability"]
         }
+    }
+
+    // ─── detectLanguage: オフライン言語検出 ─────────────────────────
+    // NLLanguageRecognizer はオンデバイスで動作するため、ネットワーク不通時も呼び出し可能。
+    // 主に Apple Translation フォールバック時に sl="auto" を解決するために使う。
+    // 戻り値: { ok: true, detectedLang: "en" / "ja" / "zh-Hans" 等, confidence: 0..1 }
+    //   or  { ok: false, error: "..." }
+    private func handleDetectLanguage(payload: [String: Any]) -> [String: Any] {
+        guard let text = payload["text"] as? String, !text.isEmpty else {
+            return ["ok": false, "error": "missing or empty text"]
+        }
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(text)
+        guard let dominant = recognizer.dominantLanguage else {
+            return ["ok": true, "detectedLang": NSNull(), "confidence": 0.0]
+        }
+        let hypotheses = recognizer.languageHypotheses(withMaximum: 1)
+        let confidence = hypotheses[dominant] ?? 0.0
+        return [
+            "ok": true,
+            "detectedLang": dominant.rawValue,
+            "confidence": confidence,
+        ]
     }
 
     // ─── translate: 実テキスト翻訳 ────────────────────────────────

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -204,20 +204,28 @@ describe('isTranslateAvailable()', () => {
 });
 
 describe('isNetworkError()', () => {
-  it('TypeError は network error 扱い（fetch ネットワーク不通の典型）', () => {
+  it('TypeError + "Failed to fetch" は network error 扱い（fetch ネットワーク不通の典型）', () => {
     expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);
   });
 
-  it('"Failed to fetch" メッセージは network error', () => {
-    expect(isNetworkError(new Error('Failed to fetch'))).toBe(true);
+  it('TypeError + "Network request failed" は network error', () => {
+    expect(isNetworkError(new TypeError('Network request failed'))).toBe(true);
   });
 
-  it('"Network request failed" は network error', () => {
-    expect(isNetworkError(new Error('Network request failed'))).toBe(true);
+  it('TypeError + "Load failed" (Safari) は network error', () => {
+    expect(isNetworkError(new TypeError('Load failed'))).toBe(true);
   });
 
-  it('"Load failed" (Safari) は network error', () => {
-    expect(isNetworkError(new Error('Load failed'))).toBe(true);
+  it('Error（非TypeError）は network error ではない（コードバグ隠蔽防止）', () => {
+    // PR #153 レビュー指摘 #1 — fetch 以外のエラーまで apple フォールバックで
+    // 隠蔽してしまう問題への対処。TypeError 以外は明示的に false にする。
+    expect(isNetworkError(new Error('Failed to fetch'))).toBe(false);
+    expect(isNetworkError(new Error('Network request failed'))).toBe(false);
+    expect(isNetworkError(new Error('Load failed'))).toBe(false);
+  });
+
+  it('TypeError でもネットワーク系メッセージでなければ false（実装バグの隠蔽防止）', () => {
+    expect(isNetworkError(new TypeError("Cannot read property 'x' of undefined"))).toBe(false);
   });
 
   it('HTTP 4xx/5xx 系のメッセージは network error ではない', () => {
@@ -230,8 +238,8 @@ describe('isNetworkError()', () => {
     expect(isNetworkError(undefined)).toBe(false);
   });
 
-  it('メッセージなしの Error は false', () => {
-    expect(isNetworkError(new Error())).toBe(false);
+  it('メッセージなしの TypeError は false', () => {
+    expect(isNetworkError(new TypeError())).toBe(false);
   });
 });
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -11,6 +11,7 @@ let getMenuTitles;
 let hasLLMApiKey;
 let isTranslateAvailable;
 let testApiKey;
+let isNetworkError;
 
 beforeAll(() => {
   const code = readFileSync(resolve(import.meta.dirname, '..', 'background.js'), 'utf-8');
@@ -37,6 +38,10 @@ beforeAll(() => {
   // isTranslateAvailable を抽出
   const translateMatch = code.match(/function isTranslateAvailable\(data\)\s*\{[\s\S]*?\n\}/);
   if (translateMatch) isTranslateAvailable = new Function('data', translateMatch[0].replace(/^function.*?\{/, '').replace(/\}$/, ''));
+
+  // isNetworkError を抽出
+  const networkErrorMatch = code.match(/function isNetworkError\(err\)\s*\{[\s\S]*?\n\}/);
+  if (networkErrorMatch) isNetworkError = new Function('err', networkErrorMatch[0].replace(/^function.*?\{/, '').replace(/\}$/, ''));
 
   // testApiKey を抽出（getDeepLEndpointに依存するため一緒にeval）
   const testApiKeyMatch = code.match(/async function testApiKey\(engine, apiKey\)\s*\{[\s\S]*?\n\}/);
@@ -195,6 +200,38 @@ describe('isTranslateAvailable()', () => {
     // chrome.storage.local.get の取得キーから appleAvailable が漏れた場合、data が
     // { translateEngine: 'apple' } のみでも安全側（false）に倒す
     expect(isTranslateAvailable({ translateEngine: 'apple', deeplApiKey: 'x' })).toBe(false);
+  });
+});
+
+describe('isNetworkError()', () => {
+  it('TypeError は network error 扱い（fetch ネットワーク不通の典型）', () => {
+    expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);
+  });
+
+  it('"Failed to fetch" メッセージは network error', () => {
+    expect(isNetworkError(new Error('Failed to fetch'))).toBe(true);
+  });
+
+  it('"Network request failed" は network error', () => {
+    expect(isNetworkError(new Error('Network request failed'))).toBe(true);
+  });
+
+  it('"Load failed" (Safari) は network error', () => {
+    expect(isNetworkError(new Error('Load failed'))).toBe(true);
+  });
+
+  it('HTTP 4xx/5xx 系のメッセージは network error ではない', () => {
+    expect(isNetworkError(new Error('Google HTTP 503'))).toBe(false);
+    expect(isNetworkError(new Error('DeepL HTTP 403'))).toBe(false);
+  });
+
+  it('null / undefined は false', () => {
+    expect(isNetworkError(null)).toBe(false);
+    expect(isNetworkError(undefined)).toBe(false);
+  });
+
+  it('メッセージなしの Error は false', () => {
+    expect(isNetworkError(new Error())).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Issue #150。Safari macOS 環境で Apple Translation が利用可能なとき、ユーザーが Google / DeepL を選択していてもネットワーク不通や fetch エラー時には黙って失敗せず、オンデバイスの Apple Translation に自動フォールバックする。

## 実装

### `background.js`

- **`isNetworkError(err)` ヘルパー追加**: `TypeError` / "Failed to fetch" / "Network request failed" / "Load failed" 等を検出。HTTP 4xx/5xx は除外
- **`fetchTranslation` を再構成**:
  1. `apple` が明示選択されていればそのまま `fetchApple`（既存）
  2. 起動時 `navigator.onLine === false` かつ apple 利用可能なら apple を最初に試行
  3. 主エンジン（Google/DeepL）の実行中に network error が発生したら apple にフォールバック
  4. `sl === 'auto'` は apple が auto 検出を提供しないためフォールバック対象外（誤訳回避）
- **戻り値に新フィールド追加**:
  - `engineUsed`: 実際に使われたエンジン（`'google'` / `'deepl'` / `'apple'`）
  - `fallback`: フォールバックが発生したかどうか
  - `fallbackReason`: `'offline'`（起動時オフライン）/ `'network-error'`（実行中エラー）

### テスト

- `tests/background.test.js` に `isNetworkError` の単体テスト 7 件追加
- 既存 444 + 新規 7 = **451 件全パス**

### CLAUDE.md

- オフラインフォールバック仕様を翻訳エンジンセクションに追記

## ブラウザ別挙動

| ブラウザ | `appleAvailable` | オフライン挙動 |
|---|---|---|
| macOS Safari | `true` | network error → apple に自動フォールバック |
| macOS Safari | `false`（言語パック未 DL 等） | 既存挙動: エラー表示 |
| Chrome / Firefox | `false` | 既存挙動: エラー表示 |
| iOS Safari | `false`（PR #149 で iOS 未実装のため） | 既存挙動 |

## 検証

- `npm test`: **451/451 passed**
- 手動検証は次のステップ:
  1. macOS Safari で Apple Translation 言語パックを DL 済みにする
  2. ブラウザを Wi-Fi Off / 機内モードでネットワーク切断
  3. 翻訳エンジンを Google または DeepL のまま、適当なページで翻訳実行
  4. console に `[DVT] google network error → apple fallback: ...` のような警告が出る
  5. 翻訳結果は正常に表示される（Apple がオンデバイスで処理）
  6. ネットワーク復帰後は元の Google / DeepL に戻る

## マージ後の動作確認手順

```
1. 拡張を再読み込み（Xcode 再ビルドして Safari 拡張の機能拡張をリロード）
2. 翻訳エンジン: Google または DeepL を選択
3. 機内モード等でネットワーク切断
4. 適当なページで翻訳実行 → 翻訳が成功する（Apple フォールバック）
5. macOS Safari 開発者ツールで console 確認: "[DVT] ... apple fallback: ..."
```

## スコープ外

- フォールバック発生時の UI 通知 / トースト表示（別 Issue で検討）
- caller 側の `auto` 渡しを apple 選択時に検出言語に置き換える対応
- iOS Safari 対応（別 Issue）

closes #150