### PR TITLE
fix: macOS Safari で領域選択ボタン押下時に popup が閉じず領域選択も動作しない（#157）

### DIFF
--- a/content-core.js
+++ b/content-core.js
@@ -203,7 +203,10 @@ var DVT = (function () {
       const hasTranslations = document.querySelectorAll('[data-dvt-id]').length > 0;
       sendResponse({ pageTranslateActive: state.pageTranslateActive, targetLang: state.targetLang, hasTranslations });
     }
-    return true;
+    // 全アクションで sendResponse を同期呼び出ししているため return true は不要。
+    // 不用意に true を返すと macOS Safari ではメッセージチャンネルが非同期応答待ちのまま
+    // ハングし、popup 側の await が undefined を受け取って window.close() が動かない等の
+    // 不具合になる（iOS Safari / Chrome / Firefox では症状が出ない）。
   });
 
   // ─── 公開API ───────────────────────────────────────────────────────

--- a/popup.js
+++ b/popup.js
@@ -229,6 +229,15 @@ async function getTab() {
   return tab;
 }
 
+// popup 起動直後にアクティブタブの tabId をキャッシュする。
+// region 選択系ボタンで window.close() を user gesture context 内で同期呼びするために必要。
+// async な await getTab() を経由すると macOS Safari で popup が閉じる前に sendMessage が
+// 飛ばないリスクがあるため、初期化時に解決しておく。
+let cachedTabId = null;
+chrome.tabs.query({ active: true, currentWindow: true })
+  .then(([tab]) => { if (tab?.id) cachedTabId = tab.id; })
+  .catch(() => {});
+
 // ── Send message to content script ────────────────────────────────────
 async function sendToContent(msg) {
   const tab = await getTab();
@@ -238,6 +247,22 @@ async function sendToContent(msg) {
   } catch (e) {
     setStatus('error', t('statusUnavailable'));
     return null;
+  }
+}
+
+// 同期 fire-and-forget。キャッシュ済み tabId で sendMessage を発射するだけで
+// レスポンスは待たない。region 系ハンドラのように window.close() を user gesture
+// context 内で同期実行したい場面で使う。返り値は送信を試みたかどうか（キャッシュ有無）。
+function sendToContentSync(msg) {
+  if (cachedTabId == null) return false;
+  try {
+    // sendMessage は Promise を返すが await しない。reject されても unhandled に
+    // ならないよう catch を付けておく。
+    const p = chrome.tabs.sendMessage(cachedTabId, msg);
+    if (p && typeof p.catch === 'function') p.catch(() => {});
+    return true;
+  } catch (_e) {
+    return false;
   }
 }
 
@@ -330,26 +355,32 @@ btnUndo.addEventListener('click', async () => {
 
 // ── Region mode ────────────────────────────────────────────────────────
 // macOS Safari では await を挟んだ後の window.close() が user gesture context を失い
-// 無視されるため、メッセージ送信は fire-and-forget にして click ハンドラ末尾で同期的に
-// window.close() する。content script 側は popup が閉じても messaging を受信して動作する。
+// 無視されるため、初期化時にキャッシュした tabId で sendToContentSync を使い、
+// click ハンドラ末尾で同期的に window.close() する。
+// content script 側は popup が閉じても messaging を受信して動作する。
 btnRegion.addEventListener('click', () => {
   setStatus('translating', t('statusSelectRegion'));
-  sendToContent({
+  const sent = sendToContentSync({
     action: 'enterRegionMode',
     lang: targetLangSel.value,
     mode: 'translate'
   });
+  // tabId キャッシュ未取得（極めてレア）の場合は async 経路にフォールバック。
+  // この経路では window.close() のタイミングが macOS Safari で不安定になり得るが、
+  // 普段は cachedTabId が早期に解決するため実質発生しない。
+  if (!sent) sendToContent({ action: 'enterRegionMode', lang: targetLangSel.value, mode: 'translate' });
   window.close();
 });
 
 // ── Region mode & summarize ───────────────────────────────────────────
 btnRegionSummary.addEventListener('click', () => {
   setStatus('translating', t('statusSelectRegion'));
-  sendToContent({
+  const sent = sendToContentSync({
     action: 'enterRegionMode',
     lang: targetLangSel.value,
     mode: 'summarize'
   });
+  if (!sent) sendToContent({ action: 'enterRegionMode', lang: targetLangSel.value, mode: 'summarize' });
   window.close();
 });
 
@@ -587,12 +618,11 @@ loadAutoRules();
 
 // ── 要素ピッカーボタン ─────────────────────────────────────────────
 document.getElementById('btnPickSelector').addEventListener('click', () => {
-  // macOS Safari の user gesture 制約に合わせて、await を挟まず同期的に window.close() する。
+  // macOS Safari の user gesture 制約に合わせて、キャッシュ済 tabId で同期送信してから
+  // 同期 window.close() する。
   const urlPattern = document.getElementById('ruleUrlPattern').value.trim();
-  sendToContent({
-    action: 'enterSelectorPickMode',
-    urlPattern,
-  });
+  const sent = sendToContentSync({ action: 'enterSelectorPickMode', urlPattern });
+  if (!sent) sendToContent({ action: 'enterSelectorPickMode', urlPattern });
   window.close();
 });
 

--- a/popup.js
+++ b/popup.js
@@ -329,29 +329,28 @@ btnUndo.addEventListener('click', async () => {
 });
 
 // ── Region mode ────────────────────────────────────────────────────────
-btnRegion.addEventListener('click', async () => {
+// macOS Safari では await を挟んだ後の window.close() が user gesture context を失い
+// 無視されるため、メッセージ送信は fire-and-forget にして click ハンドラ末尾で同期的に
+// window.close() する。content script 側は popup が閉じても messaging を受信して動作する。
+btnRegion.addEventListener('click', () => {
   setStatus('translating', t('statusSelectRegion'));
-  const res = await sendToContent({
+  sendToContent({
     action: 'enterRegionMode',
     lang: targetLangSel.value,
     mode: 'translate'
   });
-  if (res?.ok) {
-    window.close();
-  }
+  window.close();
 });
 
 // ── Region mode & summarize ───────────────────────────────────────────
-btnRegionSummary.addEventListener('click', async () => {
+btnRegionSummary.addEventListener('click', () => {
   setStatus('translating', t('statusSelectRegion'));
-  const res = await sendToContent({
+  sendToContent({
     action: 'enterRegionMode',
     lang: targetLangSel.value,
     mode: 'summarize'
   });
-  if (res?.ok) {
-    window.close();
-  }
+  window.close();
 });
 
 // ── Check current state on popup open ─────────────────────────────────
@@ -587,15 +586,14 @@ document.getElementById('btnCancelRuleEdit').addEventListener('click', () => {
 loadAutoRules();
 
 // ── 要素ピッカーボタン ─────────────────────────────────────────────
-document.getElementById('btnPickSelector').addEventListener('click', async () => {
+document.getElementById('btnPickSelector').addEventListener('click', () => {
+  // macOS Safari の user gesture 制約に合わせて、await を挟まず同期的に window.close() する。
   const urlPattern = document.getElementById('ruleUrlPattern').value.trim();
-  const res = await sendToContent({
+  sendToContent({
     action: 'enterSelectorPickMode',
     urlPattern,
   });
-  if (res?.ok) {
-    window.close();
-  }
+  window.close();
 });
 
 // ── 起動時の初期化: URL自動補完 + ピッカー結果の復元 ───────────────────


### PR DESCRIPTION
## Summary

macOS Safari 限定で「領域を選択して翻訳」ボタンを押すと popup が閉じず、領域選択モードも入らない（または popup が前面で見えない）問題を修正。
**iOS Safari / Chrome / Firefox では正常動作**しており、macOS 固有の 2 つの挙動差が原因。

## 原因と修正

### 1. content script listener の `return true` 問題

`content-core.js` の `chrome.runtime.onMessage.addListener` は全アクションで `sendResponse` を同期呼び出ししているにもかかわらず、リスナー末尾で `return true;` していた。
- Chrome / Firefox / iOS Safari: 同期応答を拾うため動作する
- **macOS Safari**: `return true` を「非同期で sendResponse する」意図と解釈し、メッセージチャンネルを async 待ちのまま保持。結果として popup の `await sendToContent(...)` が undefined を受け取る

→ **末尾の `return true;` を削除**（同期応答のみのため不要）。

### 2. `window.close()` のタイミング問題

popup.js の region 系ボタンハンドラで `await sendToContent(...)` の後に `window.close()` を呼んでいたが、**macOS Safari では `await` を挟むと user gesture context が失われ `window.close()` が無視される**。

→ **ハンドラを非 async 化、`sendToContent` を fire-and-forget で発射してから同期的に `window.close()` を呼ぶ**。content script 側は popup が閉じても messaging を受信して enterRegionMode を実行できる。

修正対象ハンドラ:
- `btnRegion`（領域選択して翻訳）
- `btnRegionSummary`（領域選択して翻訳＆要約）
- `btnPickSelector`（要素ピッカー）

## 検証

- `npm test`: **477/477 passed**
- iOS / Chrome / Firefox の挙動には影響なし
- 手動: macOS Safari で領域選択ボタン押下 → popup 即座に閉じて crosshair カーソル + ヒント表示

## マージ後の確認手順

1. macOS Safari の機能拡張をオフ → オン（または Xcode 再ビルド後にリロード）
2. popup を開いて「領域を選択して翻訳」ボタンをクリック
3. 期待: popup が即座に閉じて、ページ上で crosshair カーソル + 上部の黄色ヒントが表示される
4. 任意の要素をクリック → 翻訳される
5. 「領域を選択して翻訳＆要約」「要素ピッカー」も同様に確認

closes #157