### PR TITLE
docs: macOS Safari 版が Mac App Store で配信開始したことを各ドキュメントに反映（#160）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 [日本語](README.md) | English
 
-A browser translation extension that shows the translation **right below the original** in a dual view. Chrome / Firefox / iOS Safari supported (macOS Safari is still in App Store review).
+A browser translation extension that shows the translation **right below the original** in a dual view. Chrome / Firefox / iOS Safari / macOS Safari supported.
 
 The original text doesn't disappear when you translate, so you can always read with full context.
 
@@ -126,9 +126,13 @@ Live on the App Store since 2026-04-28:
 
 https://apps.apple.com/app/dualview-translator/id6763488360
 
-### macOS Safari (in App Store review)
+### macOS Safari
 
-Submitted to the Mac App Store on 2026-04-25, currently awaiting Apple's review. The Safari Web Extension Xcode project lives under `safari/` if you want to build locally. Build instructions are in [safari/README.md](safari/README.md).
+Live on the Mac App Store since 2026-05-01:
+
+https://apps.apple.com/app/dualview-translator/id6763488360
+
+The Safari Web Extension Xcode project lives under `safari/` if you want to build locally. Build instructions are in [safari/README.md](safari/README.md).
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 日本語 | [English](README.en.md)
 
-原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox / iOS Safari 対応（macOS Safari は App Store 審査中）。
+原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox / iOS Safari / macOS Safari に対応。
 
 翻訳しても原文が消えないので、原文を確認しながら読めます。
 
@@ -126,9 +126,13 @@ iOS App Store で配信中（2026-04-28〜）:
 
 https://apps.apple.com/jp/app/dualview-translator/id6763488360
 
-### macOS Safari（App Store 審査中）
+### macOS Safari
 
-2026-04-25 に Mac App Store へ申請済み、現在 Apple の審査結果待ちです。Safari Web Extension 対応の Xcode プロジェクトは `safari/` 以下に含まれており、ローカルビルドの手順は [safari/README.md](safari/README.md) を参照してください。
+Mac App Store で配信中（2026-05-01〜）:
+
+https://apps.apple.com/jp/app/dualview-translator/id6763488360
+
+Safari Web Extension 対応の Xcode プロジェクトは `safari/` 以下に含まれており、ローカルビルドの手順は [safari/README.md](safari/README.md) を参照してください。
 
 ## 使い方
 

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -10,6 +10,12 @@ permalink: /RELEASE_NOTES.en.html
 
 ## Unreleased
 
+### Milestones
+
+- **macOS Safari extension is now live on the Mac App Store** (2026-05-01)
+  - Public URL: https://apps.apple.com/app/dualview-translator/id6763488360
+  - All four of Chrome / Firefox / iOS Safari / macOS Safari are now served from official stores
+
 ---
 
 ## v1.5.0 (2026-05-01)

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -10,12 +10,6 @@ permalink: /RELEASE_NOTES.en.html
 
 ## Unreleased
 
-### Milestones
-
-- **macOS Safari extension is now live on the Mac App Store** (2026-05-01)
-  - Public URL: https://apps.apple.com/app/dualview-translator/id6763488360
-  - All four of Chrome / Firefox / iOS Safari / macOS Safari are now served from official stores
-
 ---
 
 ## v1.5.0 (2026-05-01)
@@ -38,7 +32,9 @@ permalink: /RELEASE_NOTES.en.html
 
 - **Now live on the Chrome Web Store** (#142)
   - Public URL: https://chromewebstore.google.com/detail/dualview-translator/hmnlfemcpbkcfppjnghiofddiiclkbmg
-  - All three of Chrome / Firefox / iOS Safari are now served from official stores (macOS Safari is still in Mac App Store review)
+- **macOS Safari extension is now live on the Mac App Store** (2026-05-01)
+  - Public URL: https://apps.apple.com/app/dualview-translator/id6763488360
+  - All four of Chrome / Firefox / iOS Safari / macOS Safari are now served from official stores
 
 ### Improvements
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,12 +10,6 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
-### マイルストーン
-
-- **macOS Safari 版が Mac App Store で配信開始**（2026-05-01）
-  - 公開 URL: https://apps.apple.com/jp/app/dualview-translator/id6763488360
-  - これで Chrome / Firefox / iOS Safari / macOS Safari の 4 チャネルすべてが正規ストアから配信される状態に
-
 ---
 
 ## v1.5.0（2026-05-01）
@@ -38,7 +32,9 @@ permalink: /RELEASE_NOTES.html
 
 - **Chrome Web Store で配信開始**（#142）
   - 公開 URL: https://chromewebstore.google.com/detail/dualview-translator/hmnlfemcpbkcfppjnghiofddiiclkbmg
-  - これで Chrome / Firefox / iOS Safari の3チャネルが正規ストアから配信される状態に（macOS Safari は引き続き Mac App Store 審査中）
+- **macOS Safari 版が Mac App Store で配信開始**（2026-05-01）
+  - 公開 URL: https://apps.apple.com/jp/app/dualview-translator/id6763488360
+  - これで Chrome / Firefox / iOS Safari / macOS Safari の 4 チャネルすべてが正規ストアから配信される状態に
 
 ### 改善
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+### マイルストーン
+
+- **macOS Safari 版が Mac App Store で配信開始**（2026-05-01）
+  - 公開 URL: https://apps.apple.com/jp/app/dualview-translator/id6763488360
+  - これで Chrome / Firefox / iOS Safari / macOS Safari の 4 チャネルすべてが正規ストアから配信される状態に
+
 ---
 
 ## v1.5.0（2026-05-01）


### PR DESCRIPTION
## Summary

DualView Translator の macOS Safari 版が **Mac App Store で公開された**ため、各ドキュメントから「審査中」記述を最新状態に更新。

公開 URL: https://apps.apple.com/jp/app/dualview-translator/id6763488360

## 変更ファイル

- **README.md / README.en.md**:
  - トップ説明文を「Chrome / Firefox / iOS Safari / macOS Safari に対応」に更新
  - 「インストール → macOS Safari」セクションを公開済みストアへのリンクに置き換え
- **docs/RELEASE_NOTES.md / RELEASE_NOTES.en.md**:
  - 「未リリース」セクションに macOS Safari 配信開始マイルストーンを追加
  - これで Chrome / Firefox / iOS Safari / macOS Safari の **4 チャネルすべて**が正規ストアから配信される状態に

ストア掲載文（chrome-web-store / firefox-add-ons）には macOS Safari への言及がなかったため変更なし。

## スコープ外

- v1.5.0 の既リリース内容の改変（既にタグ済み）

## 検証

- `npm test`: **477/477 passed**

closes #160