### PR TITLE
docs: GitHub Pages トップの macOS Safari 配布リンクを Mac App Store 公開済みに更新

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -27,7 +27,7 @@ Source code is on GitHub:
 - Chrome: [Chrome Web Store](https://chromewebstore.google.com/detail/dualview-translator/hmnlfemcpbkcfppjnghiofddiiclkbmg)
 - Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/dualview-translator/)
 - iOS Safari: [App Store](https://apps.apple.com/app/dualview-translator/id6763488360)
-- macOS Safari: Mac App Store (in review)
+- macOS Safari: [Mac App Store](https://apps.apple.com/app/dualview-translator/id6763488360)
 
 ## Developer
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Copyright (c) Orangesoft Inc.
 - Chrome: [Chrome Web Store](https://chromewebstore.google.com/detail/dualview-translator/hmnlfemcpbkcfppjnghiofddiiclkbmg)
 - Firefox: [Firefox Add-ons](https://addons.mozilla.org/ja/firefox/addon/dualview-translator/)
 - iOS Safari: [App Store](https://apps.apple.com/jp/app/dualview-translator/id6763488360)
-- macOS Safari: Mac App Store（審査中）
+- macOS Safari: [Mac App Store](https://apps.apple.com/jp/app/dualview-translator/id6763488360)
 
 ## 開発元
 


### PR DESCRIPTION
## Summary

PR #161 で README / RELEASE_NOTES は更新したが、**GitHub Pages のトップページ** `docs/index.md` / `docs/index.en.md` の「配布」セクションが「審査中」のまま残っていた。

## 変更点

- `docs/index.md`: 「macOS Safari: Mac App Store（審査中）」 → 公開済みリンクに更新
- `docs/index.en.md`: 「macOS Safari: Mac App Store (in review)」 → 公開済みリンクに更新

公開 URL: https://apps.apple.com/jp/app/dualview-translator/id6763488360

## 補足

`docs/RELEASE_NOTES.md` の v1.4.1 セクション内に「macOS Safari は引き続き Mac App Store 審査中」記述があるが、これは**当時の事実を記録した historical record** のため意図的に変更しない。