### PR TITLE
fix: Xcode の MARKETING_VERSION / CURRENT_PROJECT_VERSION を v1.5.0 に同期（#163）

### DIFF
--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -38,9 +38,23 @@ git checkout -b release/v<VERSION>
 
 ### 4. バージョン番号を更新
 
-更新対象（必ず両方同期させる）:
+更新対象（必ずすべて同期させる）:
 - `manifest.json` の `version`
 - `package.json` の `version`
+- `safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj` の以下 2 種類（iOS App Store / Mac App Store 提出に必要）:
+  - `MARKETING_VERSION` を新バージョン（例: `1.5.0`）に更新（全 8 箇所、iOS/macOS × App/Extension × Debug/Release）
+  - `CURRENT_PROJECT_VERSION` を +1 インクリメント（全 8 箇所、ビルド番号）
+
+```bash
+# 全 8 箇所一括更新の例
+sed -i '' 's/MARKETING_VERSION = <旧>;/MARKETING_VERSION = <新>;/g' \
+  "safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj"
+sed -i '' 's/CURRENT_PROJECT_VERSION = <旧>;/CURRENT_PROJECT_VERSION = <新>;/g' \
+  "safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj"
+```
+
+Xcode 側を更新し忘れると iOS App Store / Mac App Store のアップロードが
+`Invalid Pre-Release Train` / `CFBundleShortVersionString must be higher` で失敗する（過去事例: Issue #163）。
 
 ### 5. リリースノートを更新
 

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -694,7 +694,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -706,7 +706,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -729,7 +729,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -741,7 +741,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -767,7 +767,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -783,7 +783,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -810,7 +810,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -826,7 +826,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -852,7 +852,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -877,7 +877,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -900,7 +900,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -925,7 +925,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -950,7 +950,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -968,7 +968,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -995,7 +995,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1013,7 +1013,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
## Summary

iOS App Store アップロード時に以下のエラーで失敗していた問題を修正：

\`\`\`
Invalid Pre-Release Train. The train version '1.4.1' is closed for new build submissions
This bundle is invalid. The value for key CFBundleShortVersionString [1.4.1] in
the Info.plist file must contain a higher version than that of the previously
approved version [1.4.1].
\`\`\`

## 原因

PR #159 で v1.5.0 リリース準備時に \`manifest.json\` / \`package.json\` は 1.5.0 に更新したが、**Xcode プロジェクトの \`MARKETING_VERSION\` / \`CURRENT_PROJECT_VERSION\` を更新し忘れていた**。`.claude/skills/release.md` のリリース手順に Xcode プロジェクトのバージョン更新が含まれていなかったことが根本原因。

## 変更内容

### \`safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj\`

- \`MARKETING_VERSION = 1.4.1\` → \`1.5.0\`（全 8 箇所）
- \`CURRENT_PROJECT_VERSION = 4\` → \`5\`（全 8 箇所、ビルド番号 +1）

8 箇所 = iOS / macOS × App / Extension × Debug / Release。

### \`.claude/skills/release.md\`

「4. バージョン番号を更新」セクションに **Xcode プロジェクトの更新も明記**。`sed` 一括コマンド例も追加して再発防止。

## 検証

- \`xcodebuild\` (iOS Simulator): **BUILD SUCCEEDED**
- \`xcodebuild\` (macOS): **BUILD SUCCEEDED**

## マージ後の作業

1. このまま iOS App Store / Mac App Store 用にアーカイブを再作成して再アップロード
2. macOS は既に 1.4.1 で公開済のため、次回更新時に 1.5.0 を提出する形

closes #163