### PR TITLE
docs: release スキルの手順 7 git add 対象に project.pbxproj を追加（#165）

### DIFF
--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -95,7 +95,8 @@ npm test
 ### 7. コミット・push・PR作成
 
 ```bash
-git add manifest.json package.json docs/RELEASE_NOTES.md
+git add manifest.json package.json docs/RELEASE_NOTES.md \
+  "safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj"
 git commit -m "chore: v<VERSION> リリース準備（バージョン番号更新・リリースノート整備）"
 git push -u origin release/v<VERSION>
 gh pr create \


### PR DESCRIPTION
## Summary

PR #164 マージ後の Copilot レビュー指摘 follow-up。

`.claude/skills/release.md` の手順 4 で `project.pbxproj` の更新を必須に追加したが、手順 7 の `git add ...` コマンド例には含まれていなかった。手順どおりに進めると **pbxproj の更新をコミットし忘れる**可能性があるため、`git add` 対象に追加。

## 変更点

```diff
-git add manifest.json package.json docs/RELEASE_NOTES.md
+git add manifest.json package.json docs/RELEASE_NOTES.md \
+  "safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj"
```

## 経緯

- PR #164 で release スキルに Xcode 更新手順を追加（再発防止のため）
- マージ後の Copilot レビューで「手順 7 にも反映が必要」との指摘
- マージ済み PR への follow-up は別 PR で対応するルール（`.claude/rules/pr-review.md`）に従い本 PR を作成

closes #165