### PR TITLE
fix: 同一言語スキップ後の要素から要約用テキストを収集できるよう修正（#169）

### DIFF
--- a/content-page.js
+++ b/content-page.js
@@ -441,13 +441,25 @@ var DVT_PAGE = (function () {
       return;
     }
 
-    // 翻訳テキストを収集（翻訳があればそれを、同一言語でスキップされた場合は原文を使用）
+    // 翻訳テキストを収集（要約対象として LLM に渡すため）
+    // 同一言語スキップ（PR #138/#140）で wrapper が解体されているケースでは
+    // .dvt-trans / .dvt-orig が両方 null になるので、要素自身の textContent を
+    // フォールバックとして使う（日本語ページの日本語要約等で必要・Issue #169）
     const texts = [];
     elements.forEach(el => {
       const transEl = el.querySelector('.dvt-trans');
+      if (transEl && transEl.textContent.trim()) {
+        texts.push(transEl.textContent);
+        return;
+      }
       const origEl = el.querySelector('.dvt-orig');
-      if (transEl) texts.push(transEl.textContent);
-      else if (origEl) texts.push(origEl.textContent);
+      if (origEl && origEl.textContent.trim()) {
+        texts.push(origEl.textContent);
+        return;
+      }
+      // wrapper 解体後（同一言語スキップ）: 要素自身のテキストを使う
+      const fallback = el.textContent?.trim();
+      if (fallback) texts.push(fallback);
     });
     if (texts.length === 0) return;
 

--- a/tests/content-page.test.js
+++ b/tests/content-page.test.js
@@ -177,6 +177,27 @@ describe('DVT_PAGE (content-page)', () => {
     });
   });
 
+  describe('runSummarize — 同一言語スキップ後のテキスト収集フォールバック（#169）', () => {
+    // Issue #169: 日本語ページを日本語で要約するケースで、同一言語翻訳スキップにより
+    // wrapper が解体されると .dvt-trans / .dvt-orig 両方 null になり、要約に渡される
+    // テキストが空になっていた。要素自身の textContent をフォールバックとして使う。
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const code = readFileSync(resolve(__dirname, '..', 'content-page.js'), 'utf-8');
+
+    it('content-page.js: wrapper 解体後は el.textContent をフォールバックとして使う', () => {
+      // .dvt-trans / .dvt-orig 両方 null のとき el.textContent を push するフォールバック分岐
+      expect(code).toMatch(/wrapper\s*解体後/);
+      expect(code).toMatch(/el\.textContent/);
+    });
+
+    it('content-page.js: trans/orig は trim() で空文字をスキップしてフォールバックに進む', () => {
+      // 空白だけの翻訳結果や原文ブロックを誤って要約対象にしないため、trim() で空判定する
+      expect(code).toMatch(/transEl[\s\S]{0,200}textContent\.trim\(\)/);
+      expect(code).toMatch(/origEl[\s\S]{0,200}textContent\.trim\(\)/);
+    });
+  });
+
   describe('runConcurrentTranslation — 二重翻訳防止（dvt-pendingマーカー）', () => {
     it('翻訳開始直後に要素が dvt-pending マークされ filterTranslatableElements から除外される', async () => {
       // jsdom は innerText 未サポートのため textContent で代用するモックを設定

--- a/tests/content-page.test.js
+++ b/tests/content-page.test.js
@@ -1,5 +1,5 @@
 // content-page.js のDOMロジックテスト（jsdom環境）
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { loadScript } from './helpers.js';
 
 describe('DVT_PAGE (content-page)', () => {
@@ -181,20 +181,82 @@ describe('DVT_PAGE (content-page)', () => {
     // Issue #169: 日本語ページを日本語で要約するケースで、同一言語翻訳スキップにより
     // wrapper が解体されると .dvt-trans / .dvt-orig 両方 null になり、要約に渡される
     // テキストが空になっていた。要素自身の textContent をフォールバックとして使う。
-    const { readFileSync } = require('fs');
-    const { resolve } = require('path');
-    const code = readFileSync(resolve(__dirname, '..', 'content-page.js'), 'utf-8');
+    //
+    // PR #170 レビュー対応: 文字列マッチでは applyTranslation 側の同類コードにも
+    // 当たって誤ってパスし得るため、jsdom 上で実 DOM 動作を検証する統合テストに
+    // 置き換える（.claude/rules/test.md 方針）。
+    let originalSendMessage;
+    let summarizeCalls;
 
-    it('content-page.js: wrapper 解体後は el.textContent をフォールバックとして使う', () => {
-      // .dvt-trans / .dvt-orig 両方 null のとき el.textContent を push するフォールバック分岐
-      expect(code).toMatch(/wrapper\s*解体後/);
-      expect(code).toMatch(/el\.textContent/);
+    beforeEach(() => {
+      // 前テストで pageTranslateActive=true のままだと translatePageAndSummarize が
+      // undoPageTranslate して early return するため明示的にリセット
+      DVT.state.pageTranslateActive = false;
+
+      // jsdom は innerText 未サポートのため textContent で代用
+      Object.defineProperty(HTMLElement.prototype, 'innerText', {
+        get() { return this.textContent; },
+        configurable: true,
+      });
+
+      // chrome.runtime.sendMessage をスタブ
+      // - 'translate': 同一言語（detectedLang='ja', tl='ja'）として原文をそのまま返す
+      //   → applyTranslation で同一言語スキップ → wrapper 解体される
+      // - 'summarize': 受け取ったテキストを記録して mock summary を返す
+      summarizeCalls = [];
+      originalSendMessage = chrome.runtime.sendMessage;
+      chrome.runtime.sendMessage = vi.fn((msg, cb) => {
+        if (msg.action === 'translate') {
+          cb({ ok: true, result: { text: msg.text, detectedLang: 'ja' } });
+        } else if (msg.action === 'summarize') {
+          summarizeCalls.push(msg);
+          cb({ ok: true, summary: '【要約】テスト' });
+        } else {
+          cb({ ok: true });
+        }
+      });
+
+      // LLM API キー設定（runSummarize の早期 return を回避）
+      chrome.storage.local.set({ claudeApiKey: 'test-key', geminiApiKey: '' });
     });
 
-    it('content-page.js: trans/orig は trim() で空文字をスキップしてフォールバックに進む', () => {
-      // 空白だけの翻訳結果や原文ブロックを誤って要約対象にしないため、trim() で空判定する
-      expect(code).toMatch(/transEl[\s\S]{0,200}textContent\.trim\(\)/);
-      expect(code).toMatch(/origEl[\s\S]{0,200}textContent\.trim\(\)/);
+    afterEach(() => {
+      chrome.runtime.sendMessage = originalSendMessage;
+      // DOM クリア
+      document.body.innerHTML = '';
+      DVT.state.pageTranslateActive = false;
+    });
+
+    it('日本語ページを日本語で要約: wrapper 解体後の要素から本文を収集して LLM に渡す', async () => {
+      const bodyText = 'これは日本語のテスト本文です。要約対象として LLM に渡されるべき。';
+      document.body.innerHTML = `<p>${bodyText}</p>`;
+
+      DVT.state.targetLang = 'ja';
+      await DVT_PAGE.translatePageAndSummarize('ja');
+
+      // 同一言語スキップで wrapper が解体されているはず
+      expect(document.querySelector('.dvt-trans')).toBeFalsy();
+      expect(document.querySelector('.dvt-orig')).toBeFalsy();
+
+      // 要約 API が呼ばれていて、本文がテキストとして渡されている
+      expect(summarizeCalls.length).toBe(1);
+      expect(summarizeCalls[0].text).toContain('これは日本語のテスト本文です');
+
+      // 要約ブロックが DOM に挿入されている
+      expect(document.querySelector('.dvt-summary')).toBeTruthy();
+    });
+
+    it('修正前の挙動: el.textContent フォールバックが無いと texts が空になり要約 API が呼ばれない', async () => {
+      // 修正コードが将来失われた場合の検知テスト。
+      // wrapper 解体された後の要素から要約用テキストを取れない実装に戻ると、
+      // texts が空 → early return → summarizeCalls.length === 0 になる。
+      // 現行修正下では texts に el.textContent が入るので >= 1 件記録されるはず。
+      document.body.innerHTML = '<p>日本語の段落テキストです。</p>';
+      DVT.state.targetLang = 'ja';
+      await DVT_PAGE.translatePageAndSummarize('ja');
+
+      expect(summarizeCalls.length).toBeGreaterThanOrEqual(1);
+      expect(summarizeCalls[0].text.trim().length).toBeGreaterThan(0);
     });
   });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -26,6 +26,12 @@ if (typeof Range !== 'undefined' && !Range.prototype.getClientRects) {
   };
 }
 
+// jsdom は Element.scrollIntoView() を実装していない
+// content-page.js の runSummarize 等で要約ブロック挿入後に呼ばれるためダミーを置く
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
 // content-selection.js は selectionchange リスナーをタッチデバイスのみで登録するため、
 // jsdom 環境を「タッチデバイス」と判定させて selectionchange 経路もテストできるようにする。
 // (`'ontouchstart' in document.documentElement` の判定で true を返させる)


### PR DESCRIPTION
## Summary

日本語ページを日本語で要約すると要約が動作しない（空・または「テキスト不十分」のような応答）問題を修正。

## 原因

PR #138 / #140 で「翻訳結果が原文と完全一致する場合は wrapper (`.dvt-orig` + `.dvt-trans`) を解体して原文 DOM 構造を戻す」変更が入った。

| ケース | wrapper | 影響 |
|---|---|---|
| 英語ページ→日本語（実翻訳） | 残る（`.dvt-trans` に翻訳） | ✅ 既存通り動作 |
| **日本語ページ→日本語（同一言語スキップ）** | **解体される** | ❌ \`runSummarize\` で texts 空 → 要約失敗 |

### 該当コード（修正前）

```javascript
const texts = [];
elements.forEach(el => {
  const transEl = el.querySelector('.dvt-trans');
  const origEl = el.querySelector('.dvt-orig');
  if (transEl) texts.push(transEl.textContent);
  else if (origEl) texts.push(origEl.textContent);
  // ↑ wrapper 解体後はどちらも null になり何も push されない
});
if (texts.length === 0) return;
```

## 修正

- `textContent.trim()` で空文字スキップ
- 両方 null（wrapper 解体済み）なら **`el.textContent` をフォールバック**として使う

```javascript
elements.forEach(el => {
  const transEl = el.querySelector('.dvt-trans');
  if (transEl && transEl.textContent.trim()) {
    texts.push(transEl.textContent);
    return;
  }
  const origEl = el.querySelector('.dvt-orig');
  if (origEl && origEl.textContent.trim()) {
    texts.push(origEl.textContent);
    return;
  }
  // wrapper 解体後（同一言語スキップ）: 要素自身のテキストを使う
  const fallback = el.textContent?.trim();
  if (fallback) texts.push(fallback);
});
```

## 影響範囲

- **日本語ページの日本語要約**: 動作するようになる ✅
- 同一言語ペア（en→en 等）の要約: 同様に動作 ✅
- 英語→日本語の要約: 既存動作維持（変化なし）
- 既存テスト 479/479 + 新規 2 = **481 全パス**

## 検証

- `npm test`: 481/481 passed
- 手動: 日本語ページで「翻訳＆要約」を実行 → 要約が表示されることを確認

closes #169