### PR TITLE
refactor: v1.5 後ソース整理 Round 1 - 定数化 + ヘルパー集約 + コメント整理（#171）

### DIFF
--- a/background.js
+++ b/background.js
@@ -21,6 +21,19 @@ function getMenuTitles(lang) {
   return CONTEXT_MENU_TITLES[lang] || CONTEXT_MENU_TITLES['en'];
 }
 
+// ─── 翻訳エンジン名（typo 防止のため定数化） ──────────────────────
+const ENGINES = Object.freeze({ GOOGLE: 'google', DEEPL: 'deepl', APPLE: 'apple' });
+
+// SafariWebExtensionHandler.swift と一致する action 名。Swift 側と JS 側で
+// string が一致する必要があるため、定数として一元管理する。
+const NATIVE_ACTIONS = Object.freeze({
+  PING: 'ping',
+  TRANSLATE: 'translate',
+  DETECT_LANGUAGE: 'detectLanguage',
+  CHECK_LANGUAGE_AVAILABILITY: 'checkLanguageAvailability',
+  LIST_SUPPORTED_LANGUAGES: 'listSupportedLanguages',
+});
+
 // ─── LLM APIキーの有無を判定 ─────────────────────────────────────────
 function hasLLMApiKey(data) {
   return !!(data.claudeApiKey || data.geminiApiKey);
@@ -29,8 +42,8 @@ function hasLLMApiKey(data) {
 // ─── 翻訳エンジンが利用可能か判定 ──────────────────────────────────
 // DeepL: APIキーが必要 / Apple: Safari (Native Messaging が動く環境) のみ
 function isTranslateAvailable(data) {
-  if (data.translateEngine === 'deepl') return !!data.deeplApiKey;
-  if (data.translateEngine === 'apple') return !!data.appleAvailable;
+  if (data.translateEngine === ENGINES.DEEPL) return !!data.deeplApiKey;
+  if (data.translateEngine === ENGINES.APPLE) return !!data.appleAvailable;
   return true; // google はキー不要・常に利用可能
 }
 
@@ -43,20 +56,17 @@ const HAS_NATIVE_MESSAGING = typeof chrome.runtime?.sendNativeMessage === 'funct
 // Native Messaging Host (Safari ネイティブハンドラ) の bundle ID
 const NATIVE_HOST_ID = 'jp.co.orangesoft.dualview-translator';
 
-// ─── Apple Translation 利用可否を検出（Safari かどうかの実体判定） ──
-// 拡張起動時に ping を1回投げて応答を見る。Safari なら ok:true が返り、
-// Chrome / Firefox では送信自体が失敗するか応答が来ない。
-// 結果は chrome.storage.local.appleAvailable にキャッシュして popup 等から参照する。
+// ─── Apple Translation 利用可否を検出 ──────────────────────────────
+// ping を 1 回投げて応答を見て Safari かどうかを判定し、appleAvailable に永続化する。
 async function detectAppleAvailability() {
   if (!HAS_NATIVE_MESSAGING) {
     await chrome.storage.local.set({ appleAvailable: false });
     return false;
   }
   try {
-    // Promise.race でタイムアウト付き（Chrome では応答が来ずハングする）。
-    // タイムアウトが先に勝った場合、native 側の Promise が後から reject すると
-    // unhandled rejection になるため、先に空の catch を付けて握りつぶす。
-    const nativePromise = chrome.runtime.sendNativeMessage(NATIVE_HOST_ID, { action: 'ping' });
+    // タイムアウト勝利時に native promise が遅延 reject すると unhandled になるため
+    // 事前に空の catch を付けて握りつぶす。
+    const nativePromise = chrome.runtime.sendNativeMessage(NATIVE_HOST_ID, { action: NATIVE_ACTIONS.PING });
     nativePromise.catch(() => {});
     const response = await Promise.race([
       nativePromise,
@@ -234,7 +244,7 @@ function getEngineConfig() {
   return new Promise((resolve) => {
     chrome.storage.local.get(['translateEngine', 'deeplApiKey', 'appleAvailable'], (data) => {
       resolve({
-        engine: data.translateEngine || 'google',
+        engine: data.translateEngine || ENGINES.GOOGLE,
         deeplApiKey: data.deeplApiKey || '',
         appleAvailable: !!data.appleAvailable,
       });
@@ -417,7 +427,7 @@ async function detectLanguageNative(text) {
   try {
     const sample = text.slice(0, 500);
     const response = await chrome.runtime.sendNativeMessage(NATIVE_HOST_ID, {
-      action: 'detectLanguage',
+      action: NATIVE_ACTIONS.DETECT_LANGUAGE,
       text: sample,
     });
     if (!response?.ok || !response.detectedLang) return null;
@@ -428,10 +438,16 @@ async function detectLanguageNative(text) {
   }
 }
 
+// 言語コードが auto/und/空 のいずれか（=具体的な言語コードが指定されていない状態）。
+// Apple Translation は auto 検出非対応のため、これを判定して native detect に分岐する。
+function isUnspecifiedLang(sl) {
+  return !sl || sl === 'auto' || sl === 'und';
+}
+
 // Apple Translation 呼び出し前に sl を必ず具体コードに解決する。
-// すでに具体コードならそのまま、auto / und / 空 ならネイティブ言語検出を経由する。
+// 具体コードならそのまま、auto/und/空 ならネイティブ言語検出を経由する。
 async function ensureExplicitSourceLang(sl, text) {
-  if (sl && sl !== 'auto' && sl !== 'und') return sl;
+  if (!isUnspecifiedLang(sl)) return sl;
   const detected = await detectLanguageNative(text);
   if (!detected) {
     throw new Error('Apple Translation: language detection failed (offline)');
@@ -440,42 +456,38 @@ async function ensureExplicitSourceLang(sl, text) {
 }
 
 // ─── 翻訳ディスパッチャー ────────────────────────────────────────────
-// オフラインフォールバック動作:
-// - apple が明示選択されていればそのまま fetchApple（sl が auto なら native 検出で解決）
-// - 主エンジン (Google/DeepL) はチャンク単位に内部キャッシュを参照するため、
-//   フル cache hit ならネットワーク要求を発行せずオフラインでも成功する。
-//   キャッシュを優先するため `navigator.onLine` 早期バイパスは行わない
-//   （cache を無視して無駄に Apple ネイティブ呼び出しになることを防ぐ）。
-// - 主エンジン実行中に network error が発生した場合に apple にフォールバック
-// - sl が auto/未指定でも NLLanguageRecognizer でオフライン検出するため、フォールバックは
-//   主要言語に対しては問題なく動作する（ただし検出失敗時はエラー）
+// 主エンジン (Google/DeepL) はチャンク単位の内部キャッシュを持つため、cache hit
+// ではネットワーク要求が発行されずオフラインでも成功する。よって navigator.onLine
+// での早期バイパスはせず、cache 優先で動かす。主エンジンが network error で失敗
+// したときのみ Apple にフォールバックする。
 async function fetchTranslation(text, tl, sl, config) {
   if (!text || !text.trim()) return { text: '', detectedLang: null, engineUsed: null };
 
   // 明示選択された apple は直行（sl が auto なら native 検出で具体コードに解決）
-  if (config.engine === 'apple' && config.appleAvailable) {
+  if (config.engine === ENGINES.APPLE && config.appleAvailable) {
     const finalSl = await ensureExplicitSourceLang(sl, text);
     const result = await fetchApple(text, tl, finalSl);
-    return { ...result, engineUsed: 'apple' };
+    return { ...result, engineUsed: ENGINES.APPLE };
   }
 
-  // 主エンジン実行（network error は apple フォールバック対象）。
-  // config.engine='deepl' でも APIキー未設定なら Google にフォールスルーするため、
-  // 実際に呼ばれたエンジンを primaryEngine として保持し、ログ・engineUsed の出力を一致させる。
-  const primaryEngine = (config.engine === 'deepl' && config.deeplApiKey) ? 'deepl' : 'google';
+  // 主エンジン実行。deepl 選択中で APIキー未設定なら Google にフォールスルーするため、
+  // 実際に呼ばれたエンジンを primaryEngine として保持してログ・engineUsed と一致させる。
+  const primaryEngine = (config.engine === ENGINES.DEEPL && config.deeplApiKey)
+    ? ENGINES.DEEPL
+    : ENGINES.GOOGLE;
   try {
-    if (primaryEngine === 'deepl') {
+    if (primaryEngine === ENGINES.DEEPL) {
       const result = await fetchDeepL(text, tl, sl, config.deeplApiKey);
-      return { ...result, engineUsed: 'deepl' };
+      return { ...result, engineUsed: ENGINES.DEEPL };
     }
     const result = await fetchGoogle(text, tl, sl);
-    return { ...result, engineUsed: 'google' };
+    return { ...result, engineUsed: ENGINES.GOOGLE };
   } catch (err) {
     if (config.appleAvailable && isNetworkError(err)) {
       console.warn(`[DVT] ${primaryEngine} network error → apple fallback:`, err.message);
       const finalSl = await ensureExplicitSourceLang(sl, text);
       const result = await fetchApple(text, tl, finalSl);
-      return { ...result, engineUsed: 'apple', fallback: true, fallbackReason: 'network-error' };
+      return { ...result, engineUsed: ENGINES.APPLE, fallback: true, fallbackReason: 'network-error' };
     }
     throw err;
   }
@@ -499,7 +511,7 @@ async function fetchGoogle(text, tl, sl) {
   let detectedLang = null;
 
   for (const chunk of chunks) {
-    const cacheKey = await buildCacheKey('google', sl, tl, chunk);
+    const cacheKey = await buildCacheKey(ENGINES.GOOGLE, sl, tl, chunk);
     let entry = await getCached(cacheKey);
     if (!entry) {
       const fetched = await fetchGoogleChunk(chunk, sl, tl);
@@ -514,21 +526,14 @@ async function fetchGoogle(text, tl, sl) {
 }
 
 // ─── Apple Translation（Safari ネイティブ呼び出し） ───────────────────
-// PR #149 で実装した SafariWebExtensionHandler の translate アクションを呼ぶ。
-// ネットワーク不要・オンデバイスで動作するが Safari でしか利用できない。
-//
-// sendNativeMessage は Safari MV3 では Promise を返す（Chrome でも MV3 は Promise 対応）。
-// callback シグネチャだと Safari で undefined response になるケースがあるため Promise 形式で呼ぶ。
-//
-// Apple Translation framework は source 言語の "auto" 検出を提供しない。
-// sl が "auto" / 空 / "und" の場合は誤訳を避けるため明示エラーを返す。
-// 上位層（content-bar の言語検出 / popup の sl 選択）で具体的な言語コードを渡す責務を持つ。
+// SafariWebExtensionHandler の translate アクションを Promise 形式で呼ぶ
+// （callback 形式だと Safari で undefined response になるケースがあるため）。
 async function fetchAppleChunk(chunk, sl, tl) {
-  if (!sl || sl === 'auto' || sl === 'und') {
+  if (isUnspecifiedLang(sl)) {
     throw new Error('Apple Translation requires explicit source language; "auto" detection is not supported');
   }
   const response = await chrome.runtime.sendNativeMessage(NATIVE_HOST_ID, {
-    action: 'translate',
+    action: NATIVE_ACTIONS.TRANSLATE,
     source: sl,
     target: tl,
     text: chunk,
@@ -544,7 +549,7 @@ async function fetchApple(text, tl, sl) {
   const results = [];
 
   for (const chunk of chunks) {
-    const cacheKey = await buildCacheKey('apple', sl, tl, chunk);
+    const cacheKey = await buildCacheKey(ENGINES.APPLE, sl, tl, chunk);
     let entry = await getCached(cacheKey);
     if (!entry) {
       const fetched = await fetchAppleChunk(chunk, sl, tl);
@@ -622,7 +627,7 @@ async function fetchDeepL(text, tl, sl, apiKey) {
   let detectedLang = null;
 
   for (const chunk of chunks) {
-    const cacheKey = await buildCacheKey('deepl', sl, tl, chunk);
+    const cacheKey = await buildCacheKey(ENGINES.DEEPL, sl, tl, chunk);
     let entry = await getCached(cacheKey);
     if (!entry) {
       const fetched = await fetchDeepLChunk(chunk, sl, tl, apiKey);

--- a/content-core.js
+++ b/content-core.js
@@ -201,7 +201,7 @@ var DVT = (function () {
       sendResponse({ pageTranslateActive: state.pageTranslateActive, targetLang: state.targetLang, hasTranslations });
     }
     // macOS Safari は同期 sendResponse + return true でチャンネルがハングするため、
-    // 全アクション同期応答のここでは return しない。
+    // 全アクション同期応答のここでは return true を返さない（= 非同期応答にしない）。
   });
 
   // ─── 公開API ───────────────────────────────────────────────────────

--- a/content-core.js
+++ b/content-core.js
@@ -14,9 +14,7 @@ var DVT = (function () {
     translateBar: null,
     lastContextMenuTarget: null,
     regionMode: false,
-    // ページの life cycle 内で 1 度だけフォールバック通知トーストを表示するフラグ。
-    // 連続翻訳でトーストが大量に出ないよう、最初の 1 回だけ表示する。
-    // ページ遷移で content script が再読み込みされるとリセットされる。
+    // フォールバック通知トーストを 1 ページ life cycle 内で 1 度だけ表示するためのフラグ
     fallbackToastShown: false,
   };
 
@@ -40,8 +38,7 @@ var DVT = (function () {
       chrome.runtime.sendMessage({ action: 'translate', text, tl, sl }, (res) => {
         if (chrome.runtime.lastError) { resolve({ text: t('error'), detectedLang: null }); return; }
         if (res?.ok) {
-          // Apple Translation へのオフラインフォールバックが発生したらトーストで通知。
-          // ページ life cycle 内で 1 度だけ表示し、連続翻訳での通知スパムを避ける。
+          // Apple フォールバック発生時の通知（ページ life cycle 内 1 回まで）
           if (res.result?.fallback && !state.fallbackToastShown) {
             state.fallbackToastShown = true;
             showToast(t('fallbackToApple'), false, 5000);
@@ -203,10 +200,8 @@ var DVT = (function () {
       const hasTranslations = document.querySelectorAll('[data-dvt-id]').length > 0;
       sendResponse({ pageTranslateActive: state.pageTranslateActive, targetLang: state.targetLang, hasTranslations });
     }
-    // 全アクションで sendResponse を同期呼び出ししているため return true は不要。
-    // 不用意に true を返すと macOS Safari ではメッセージチャンネルが非同期応答待ちのまま
-    // ハングし、popup 側の await が undefined を受け取って window.close() が動かない等の
-    // 不具合になる（iOS Safari / Chrome / Firefox では症状が出ない）。
+    // macOS Safari は同期 sendResponse + return true でチャンネルがハングするため、
+    // 全アクション同期応答のここでは return しない。
   });
 
   // ─── 公開API ───────────────────────────────────────────────────────

--- a/popup.js
+++ b/popup.js
@@ -266,6 +266,15 @@ function sendToContentSync(msg) {
   }
 }
 
+// region 系・要素ピッカー系の共通シーケンス: 同期送信 → 失敗時 async fallback → 同期 close。
+// macOS Safari では await を挟むと user gesture context が失われ window.close() が無視される
+// ため、必ず click ハンドラ末尾で同期的に close を呼ぶ必要がある。
+function sendToContentAndClose(msg) {
+  const sent = sendToContentSync(msg);
+  if (!sent) sendToContent(msg);
+  window.close();
+}
+
 // ── Status helpers ─────────────────────────────────────────────────────
 function setStatus(type, text) {
   statusText.textContent = text;
@@ -354,34 +363,23 @@ btnUndo.addEventListener('click', async () => {
 });
 
 // ── Region mode ────────────────────────────────────────────────────────
-// macOS Safari では await を挟んだ後の window.close() が user gesture context を失い
-// 無視されるため、初期化時にキャッシュした tabId で sendToContentSync を使い、
-// click ハンドラ末尾で同期的に window.close() する。
-// content script 側は popup が閉じても messaging を受信して動作する。
 btnRegion.addEventListener('click', () => {
   setStatus('translating', t('statusSelectRegion'));
-  const sent = sendToContentSync({
+  sendToContentAndClose({
     action: 'enterRegionMode',
     lang: targetLangSel.value,
-    mode: 'translate'
+    mode: 'translate',
   });
-  // tabId キャッシュ未取得（極めてレア）の場合は async 経路にフォールバック。
-  // この経路では window.close() のタイミングが macOS Safari で不安定になり得るが、
-  // 普段は cachedTabId が早期に解決するため実質発生しない。
-  if (!sent) sendToContent({ action: 'enterRegionMode', lang: targetLangSel.value, mode: 'translate' });
-  window.close();
 });
 
 // ── Region mode & summarize ───────────────────────────────────────────
 btnRegionSummary.addEventListener('click', () => {
   setStatus('translating', t('statusSelectRegion'));
-  const sent = sendToContentSync({
+  sendToContentAndClose({
     action: 'enterRegionMode',
     lang: targetLangSel.value,
-    mode: 'summarize'
+    mode: 'summarize',
   });
-  if (!sent) sendToContent({ action: 'enterRegionMode', lang: targetLangSel.value, mode: 'summarize' });
-  window.close();
 });
 
 // ── Check current state on popup open ─────────────────────────────────
@@ -618,12 +616,8 @@ loadAutoRules();
 
 // ── 要素ピッカーボタン ─────────────────────────────────────────────
 document.getElementById('btnPickSelector').addEventListener('click', () => {
-  // macOS Safari の user gesture 制約に合わせて、キャッシュ済 tabId で同期送信してから
-  // 同期 window.close() する。
   const urlPattern = document.getElementById('ruleUrlPattern').value.trim();
-  const sent = sendToContentSync({ action: 'enterSelectorPickMode', urlPattern });
-  if (!sent) sendToContent({ action: 'enterSelectorPickMode', urlPattern });
-  window.close();
+  sendToContentAndClose({ action: 'enterSelectorPickMode', urlPattern });
 });
 
 // ── 起動時の初期化: URL自動補完 + ピッカー結果の復元 ───────────────────

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -35,9 +35,13 @@ beforeAll(() => {
   const hasKeyMatch = code.match(/function hasLLMApiKey\(data\)\s*\{[\s\S]*?\n\}/);
   if (hasKeyMatch) hasLLMApiKey = new Function('data', hasKeyMatch[0].replace(/^function.*?\{/, '').replace(/\}$/, ''));
 
-  // isTranslateAvailable を抽出
+  // isTranslateAvailable を抽出（ENGINES 定数を参照するので一緒に eval する）
+  const enginesMatch = code.match(/const ENGINES = Object\.freeze\(\{[^}]+\}\);/);
   const translateMatch = code.match(/function isTranslateAvailable\(data\)\s*\{[\s\S]*?\n\}/);
-  if (translateMatch) isTranslateAvailable = new Function('data', translateMatch[0].replace(/^function.*?\{/, '').replace(/\}$/, ''));
+  if (translateMatch && enginesMatch) {
+    const combined = `${enginesMatch[0]}\n${translateMatch[0]}\nreturn isTranslateAvailable;`;
+    isTranslateAvailable = new Function(combined)();
+  }
 
   // isNetworkError を抽出
   const networkErrorMatch = code.match(/function isNetworkError\(err\)\s*\{[\s\S]*?\n\}/);

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -35,13 +35,14 @@ beforeAll(() => {
   const hasKeyMatch = code.match(/function hasLLMApiKey\(data\)\s*\{[\s\S]*?\n\}/);
   if (hasKeyMatch) hasLLMApiKey = new Function('data', hasKeyMatch[0].replace(/^function.*?\{/, '').replace(/\}$/, ''));
 
-  // isTranslateAvailable を抽出（ENGINES 定数を参照するので一緒に eval する）
-  const enginesMatch = code.match(/const ENGINES = Object\.freeze\(\{[^}]+\}\);/);
-  const translateMatch = code.match(/function isTranslateAvailable\(data\)\s*\{[\s\S]*?\n\}/);
-  if (translateMatch && enginesMatch) {
-    const combined = `${enginesMatch[0]}\n${translateMatch[0]}\nreturn isTranslateAvailable;`;
-    isTranslateAvailable = new Function(combined)();
-  }
+  // isTranslateAvailable を抽出（ENGINES 定数を参照するので一緒に eval する）。
+  // どちらかの正規表現が match 失敗するとテスト全体が無音で壊れるため fail-fast にする。
+  const enginesMatch = code.match(/const\s+ENGINES\s*=\s*Object\.freeze\(\{[\s\S]*?\}\);/);
+  const translateMatch = code.match(/function\s+isTranslateAvailable\s*\(data\)\s*\{[\s\S]*?\n\}/);
+  if (!enginesMatch) throw new Error('background.test.js: ENGINES 定数の正規表現抽出に失敗（background.js のフォーマット変更を確認）');
+  if (!translateMatch) throw new Error('background.test.js: isTranslateAvailable の正規表現抽出に失敗（background.js のフォーマット変更を確認）');
+  const combined = `${enginesMatch[0]}\n${translateMatch[0]}\nreturn isTranslateAvailable;`;
+  isTranslateAvailable = new Function(combined)();
 
   // isNetworkError を抽出
   const networkErrorMatch = code.match(/function isNetworkError\(err\)\s*\{[\s\S]*?\n\}/);


### PR DESCRIPTION
## Summary

\`/skill simplify\` で 3 エージェント並列レビューを実施した結果、多数の改善余地が判明。リスクを抑えるため 4 ラウンドに分割し、本 PR は **Round 1（最小リスク・挙動変化なし）**。

## 変更内容

### A. 定数化

\`background.js\` 上部に：

\`\`\`js
const ENGINES = Object.freeze({ GOOGLE: 'google', DEEPL: 'deepl', APPLE: 'apple' });
const NATIVE_ACTIONS = Object.freeze({
  PING: 'ping',
  TRANSLATE: 'translate',
  DETECT_LANGUAGE: 'detectLanguage',
  CHECK_LANGUAGE_AVAILABILITY: 'checkLanguageAvailability',
  LIST_SUPPORTED_LANGUAGES: 'listSupportedLanguages',
});
\`\`\`

- 翻訳エンジン名リテラル（10 箇所）を \`ENGINES.*\` に置換
- native action 名リテラル（3 箇所）を \`NATIVE_ACTIONS.*\` に置換
- \`tests/background.test.js\` の eval 抽出に ENGINES を含めるよう調整

### B. ヘルパー抽出

- **\`isUnspecifiedLang(sl)\`** in \`background.js\`: \`!sl || sl === 'auto' || sl === 'und'\` を 2 箇所（\`ensureExplicitSourceLang\` / \`fetchAppleChunk\`）から集約
- **\`sendToContentAndClose(msg)\`** in \`popup.js\`: btnRegion / btnRegionSummary / btnPickSelector の 3 ハンドラから「sync → fallback async → \`window.close()\`」コピペを集約

### C. コメント整理（CLAUDE.md：WHY のみ残す）

- PR/Issue 番号への参照や HOW 説明を削減
- \`background.js\`: \`detectAppleAvailability\` / \`fetchAppleChunk\` / \`fetchTranslation\` ディスパッチャの説明を要点のみに圧縮
- \`content-core.js\`: \`state.fallbackToastShown\` / リスナー末尾コメントを 1-2 行に

## スコープ外（Round 2 以降）

- Round 2: \`fetchChunkedWithCache\` 共通化 + チャンク並列化
- Round 3: \`getEngineConfig\` モジュールキャッシュ + \`evictIfNeeded\` 効率化
- Round 4: Swift 側整理（availability ヘルパー / HiddenHostHolder.window.close 等）

## 検証

- \`npm test\`: **481/481 passed**
- 挙動変化なし

## 差分

- 4 files changed, **76 insertions / 78 deletions**（差し引き -2 行、可読性向上）

closes #171