### PR TITLE
refactor: v1.5 後ソース整理 Round 3 - getEngineConfig キャッシュ化 + evict 効率化（#176）

### DIFF
--- a/background.js
+++ b/background.js
@@ -239,13 +239,15 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 });
 
-// ─── エンジン設定をstorageから取得（モジュールキャッシュ + onChanged 連動） ─
+// ─── エンジン設定をstorageから取得（Promise キャッシュ + onChanged 連動） ──
 // ページ全体翻訳・MutationObserver 連動翻訳では数十〜数百要素を並行翻訳するため、
 // 毎回 storage.local.get するとホットパスで storage IO が多重発生する。
-// 初回 / invalidate 後に 1 度だけ読んで以降はメモリキャッシュから返し、
-// 関連キー（translateEngine / deeplApiKey / appleAvailable）が変わったら invalidate する。
-let engineConfigCache = null;
+// engineConfigCache に Promise<Config> を保持することで:
+// - 並列で getEngineConfig() が呼ばれても in-flight の Promise を共有（重複 IO なし）
+// - resolve 後は同じ Promise を返すだけなのでキャッシュとして機能
+// 関連キーが変わったら null にして次回呼び出しで再ロードする。
 const ENGINE_CONFIG_KEYS = ['translateEngine', 'deeplApiKey', 'appleAvailable'];
+let engineConfigCache = null; // Promise<Config> | null
 
 function loadEngineConfig() {
   return new Promise((resolve) => {
@@ -259,9 +261,10 @@ function loadEngineConfig() {
   });
 }
 
-async function getEngineConfig() {
-  if (engineConfigCache) return engineConfigCache;
-  engineConfigCache = await loadEngineConfig();
+function getEngineConfig() {
+  if (!engineConfigCache) {
+    engineConfigCache = loadEngineConfig();
+  }
   return engineConfigCache;
 }
 
@@ -295,6 +298,27 @@ const CLAUDE_SUMMARY_MODEL = 'claude-haiku-4-5-20251001';
 const storageGet = (keys) => new Promise(resolve => chrome.storage.local.get(keys, resolve));
 const storageSet = (items) => new Promise(resolve => chrome.storage.local.set(items, resolve));
 const storageRemove = (keys) => new Promise(resolve => chrome.storage.local.remove(keys, resolve));
+
+// chrome.storage.local.getKeys (Chrome 121+) は Promise / callback 両形式の実装が
+// 混在しうる。await が undefined にならないよう Promise 化のラッパーで吸収する。
+// 関数自体が無い環境では null を返し、呼び出し側でフォールバックする。
+function storageGetKeys() {
+  if (typeof chrome.storage.local.getKeys !== 'function') return null;
+  return new Promise((resolve, reject) => {
+    try {
+      const result = chrome.storage.local.getKeys((keys) => {
+        if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+        else resolve(keys);
+      });
+      // Promise を返す実装（Chrome MV3 / Firefox）に対応
+      if (result && typeof result.then === 'function') {
+        result.then(resolve, reject);
+      }
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
 
 // text の SHA-256 先頭16文字（8バイト）をキーに使う。<10000件なら衝突実質ゼロ
 async function hashText(text) {
@@ -364,19 +388,21 @@ async function setCached(key, entry) {
 
 // プレフィックス単位の LRU eviction
 // 指定 prefix に該当するキャッシュエントリだけを storage から取得する。
-// storage.local.get(null) で全件取得すると自動翻訳ルール等の非キャッシュデータも
-// 転送されるため、prefix が分かっているときはこちらを使う方が軽い。
-// 戻り値は { 'tc:xxx': {translated, ts}, ... } の object。
+// chrome.storage.local.getKeys() (Chrome 121+) があればキー一覧だけ取って必要分を
+// get（軽量）、無ければ get(null) フォールバック（自動翻訳ルール等まで含む全件取得）。
 async function getCacheEntriesByPrefix(prefix) {
-  // chrome.storage.local.getKeys() が存在すればそれでキー一覧だけ取得 → 必要分のみ get
-  // しなければ get(null) フォールバック（既存挙動）
-  if (typeof chrome.storage.local.getKeys === 'function') {
-    const allKeys = await chrome.storage.local.getKeys();
-    const filtered = allKeys.filter((k) => k.startsWith(prefix));
+  const keys = await storageGetKeys();
+  if (keys) {
+    const filtered = keys.filter((k) => k.startsWith(prefix));
     if (filtered.length === 0) return {};
     return await storageGet(filtered);
   }
-  const all = await storageGet(null);
+  return pickEntriesByPrefix(await storageGet(null), prefix);
+}
+
+// オブジェクトから指定 prefix のエントリを抽出するピュア関数。
+// フォールバックパスで storageGet(null) を 1 回だけ呼んで複数 prefix を処理するときに使う。
+function pickEntriesByPrefix(all, prefix) {
   const filtered = {};
   for (const k of Object.keys(all)) {
     if (k.startsWith(prefix)) filtered[k] = all[k];
@@ -384,8 +410,8 @@ async function getCacheEntriesByPrefix(prefix) {
   return filtered;
 }
 
-async function evictByPrefix(prefix, maxEntries, evictRatio) {
-  const entries = await getCacheEntriesByPrefix(prefix);
+// LRU evict 本体。entries は { key: {translated, ts}, ... } の形。
+async function evictEntries(entries, maxEntries, evictRatio) {
   const keys = Object.keys(entries);
   if (keys.length <= maxEntries) return;
   const sorted = keys
@@ -395,17 +421,36 @@ async function evictByPrefix(prefix, maxEntries, evictRatio) {
   await storageRemove(sorted.slice(0, toEvict).map(x => x.key));
 }
 
+async function evictByPrefix(prefix, maxEntries, evictRatio) {
+  await evictEntries(await getCacheEntriesByPrefix(prefix), maxEntries, evictRatio);
+}
+
 async function evictIfNeeded() {
-  // 翻訳キャッシュ・要約キャッシュをそれぞれ独立して evict
-  await evictByPrefix(TC_PREFIX, TC_MAX_ENTRIES, TC_EVICT_RATIO);
-  await evictByPrefix(SC_PREFIX, SC_MAX_ENTRIES, SC_EVICT_RATIO);
+  // 翻訳キャッシュ・要約キャッシュをそれぞれ独立して evict。
+  // getKeys 対応環境では各 prefix 個別に軽量取得で問題ない。
+  // 非対応環境では get(null) を 1 回だけ呼んで両 prefix を処理し、IO を節約する。
+  const keys = await storageGetKeys();
+  if (keys) {
+    await evictByPrefix(TC_PREFIX, TC_MAX_ENTRIES, TC_EVICT_RATIO);
+    await evictByPrefix(SC_PREFIX, SC_MAX_ENTRIES, SC_EVICT_RATIO);
+    return;
+  }
+  const all = await storageGet(null);
+  await evictEntries(pickEntriesByPrefix(all, TC_PREFIX), TC_MAX_ENTRIES, TC_EVICT_RATIO);
+  await evictEntries(pickEntriesByPrefix(all, SC_PREFIX), SC_MAX_ENTRIES, SC_EVICT_RATIO);
 }
 
 // 翻訳・要約キャッシュを両方クリア（ヒット率統計もリセット）
 async function clearCache() {
-  const tcEntries = await getCacheEntriesByPrefix(TC_PREFIX);
-  const scEntries = await getCacheEntriesByPrefix(SC_PREFIX);
-  const cacheKeys = [...Object.keys(tcEntries), ...Object.keys(scEntries)];
+  // evictIfNeeded と同じく、フォールバック時は get(null) を 1 回だけ呼ぶ
+  const keys = await storageGetKeys();
+  let cacheKeys;
+  if (keys) {
+    cacheKeys = keys.filter(k => k.startsWith(TC_PREFIX) || k.startsWith(SC_PREFIX));
+  } else {
+    const all = await storageGet(null);
+    cacheKeys = Object.keys(all).filter(k => k.startsWith(TC_PREFIX) || k.startsWith(SC_PREFIX));
+  }
   const keysToRemove = cacheKeys.length > 0 ? [...cacheKeys, HIT_STATS_KEY] : [HIT_STATS_KEY];
   await storageRemove(keysToRemove);
   return cacheKeys.length;
@@ -419,21 +464,13 @@ function calcHitRate(hits, misses) {
 
 async function getCacheStats() {
   // entries 数と hit rate しか必要ないので prefix 別にキー数だけ数える。
-  // 全 storage 取得 → object 化 → filter よりキーだけ列挙する方が軽い。
   let tcEntries = 0;
   let scEntries = 0;
-  if (typeof chrome.storage.local.getKeys === 'function') {
-    const allKeys = await chrome.storage.local.getKeys();
-    for (const k of allKeys) {
-      if (k.startsWith(TC_PREFIX)) tcEntries++;
-      else if (k.startsWith(SC_PREFIX)) scEntries++;
-    }
-  } else {
-    const all = await storageGet(null);
-    for (const k of Object.keys(all)) {
-      if (k.startsWith(TC_PREFIX)) tcEntries++;
-      else if (k.startsWith(SC_PREFIX)) scEntries++;
-    }
+  const keys = await storageGetKeys();
+  const sourceKeys = keys || Object.keys(await storageGet(null));
+  for (const k of sourceKeys) {
+    if (k.startsWith(TC_PREFIX)) tcEntries++;
+    else if (k.startsWith(SC_PREFIX)) scEntries++;
   }
   const data = await storageGet(HIT_STATS_KEY);
   const s = data[HIT_STATS_KEY] || { tcHits: 0, tcMisses: 0, scHits: 0, scMisses: 0 };

--- a/background.js
+++ b/background.js
@@ -239,10 +239,17 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 });
 
-// ─── エンジン設定をstorageから取得 ────────────────────────────────────
-function getEngineConfig() {
+// ─── エンジン設定をstorageから取得（モジュールキャッシュ + onChanged 連動） ─
+// ページ全体翻訳・MutationObserver 連動翻訳では数十〜数百要素を並行翻訳するため、
+// 毎回 storage.local.get するとホットパスで storage IO が多重発生する。
+// 初回 / invalidate 後に 1 度だけ読んで以降はメモリキャッシュから返し、
+// 関連キー（translateEngine / deeplApiKey / appleAvailable）が変わったら invalidate する。
+let engineConfigCache = null;
+const ENGINE_CONFIG_KEYS = ['translateEngine', 'deeplApiKey', 'appleAvailable'];
+
+function loadEngineConfig() {
   return new Promise((resolve) => {
-    chrome.storage.local.get(['translateEngine', 'deeplApiKey', 'appleAvailable'], (data) => {
+    chrome.storage.local.get(ENGINE_CONFIG_KEYS, (data) => {
       resolve({
         engine: data.translateEngine || ENGINES.GOOGLE,
         deeplApiKey: data.deeplApiKey || '',
@@ -251,6 +258,19 @@ function getEngineConfig() {
     });
   });
 }
+
+async function getEngineConfig() {
+  if (engineConfigCache) return engineConfigCache;
+  engineConfigCache = await loadEngineConfig();
+  return engineConfigCache;
+}
+
+// 関連キーの変更を監視してキャッシュを invalidate
+chrome.storage.onChanged.addListener((changes) => {
+  if (ENGINE_CONFIG_KEYS.some((k) => k in changes)) {
+    engineConfigCache = null;
+  }
+});
 
 // ─── 翻訳・要約キャッシュ ────────────────────────────────────────────
 // Google/DeepL 翻訳結果を tc: プレフィックス、Claude/Gemini 要約を sc: プレフィックスでキャッシュ。
@@ -343,27 +363,49 @@ async function setCached(key, entry) {
 }
 
 // プレフィックス単位の LRU eviction
-async function evictByPrefix(all, prefix, maxEntries, evictRatio) {
-  const keys = Object.keys(all).filter(k => k.startsWith(prefix));
+// 指定 prefix に該当するキャッシュエントリだけを storage から取得する。
+// storage.local.get(null) で全件取得すると自動翻訳ルール等の非キャッシュデータも
+// 転送されるため、prefix が分かっているときはこちらを使う方が軽い。
+// 戻り値は { 'tc:xxx': {translated, ts}, ... } の object。
+async function getCacheEntriesByPrefix(prefix) {
+  // chrome.storage.local.getKeys() が存在すればそれでキー一覧だけ取得 → 必要分のみ get
+  // しなければ get(null) フォールバック（既存挙動）
+  if (typeof chrome.storage.local.getKeys === 'function') {
+    const allKeys = await chrome.storage.local.getKeys();
+    const filtered = allKeys.filter((k) => k.startsWith(prefix));
+    if (filtered.length === 0) return {};
+    return await storageGet(filtered);
+  }
+  const all = await storageGet(null);
+  const filtered = {};
+  for (const k of Object.keys(all)) {
+    if (k.startsWith(prefix)) filtered[k] = all[k];
+  }
+  return filtered;
+}
+
+async function evictByPrefix(prefix, maxEntries, evictRatio) {
+  const entries = await getCacheEntriesByPrefix(prefix);
+  const keys = Object.keys(entries);
   if (keys.length <= maxEntries) return;
   const sorted = keys
-    .map(k => ({ key: k, ts: all[k]?.ts || 0 }))
+    .map(k => ({ key: k, ts: entries[k]?.ts || 0 }))
     .sort((a, b) => a.ts - b.ts);
   const toEvict = Math.ceil(keys.length * evictRatio);
   await storageRemove(sorted.slice(0, toEvict).map(x => x.key));
 }
 
 async function evictIfNeeded() {
-  const all = await storageGet(null);
   // 翻訳キャッシュ・要約キャッシュをそれぞれ独立して evict
-  await evictByPrefix(all, TC_PREFIX, TC_MAX_ENTRIES, TC_EVICT_RATIO);
-  await evictByPrefix(all, SC_PREFIX, SC_MAX_ENTRIES, SC_EVICT_RATIO);
+  await evictByPrefix(TC_PREFIX, TC_MAX_ENTRIES, TC_EVICT_RATIO);
+  await evictByPrefix(SC_PREFIX, SC_MAX_ENTRIES, SC_EVICT_RATIO);
 }
 
 // 翻訳・要約キャッシュを両方クリア（ヒット率統計もリセット）
 async function clearCache() {
-  const all = await storageGet(null);
-  const cacheKeys = Object.keys(all).filter(k => k.startsWith(TC_PREFIX) || k.startsWith(SC_PREFIX));
+  const tcEntries = await getCacheEntriesByPrefix(TC_PREFIX);
+  const scEntries = await getCacheEntriesByPrefix(SC_PREFIX);
+  const cacheKeys = [...Object.keys(tcEntries), ...Object.keys(scEntries)];
   const keysToRemove = cacheKeys.length > 0 ? [...cacheKeys, HIT_STATS_KEY] : [HIT_STATS_KEY];
   await storageRemove(keysToRemove);
   return cacheKeys.length;
@@ -376,11 +418,25 @@ function calcHitRate(hits, misses) {
 }
 
 async function getCacheStats() {
-  const all = await storageGet(null);
-  const keys = Object.keys(all);
-  const tcEntries = keys.filter(k => k.startsWith(TC_PREFIX)).length;
-  const scEntries = keys.filter(k => k.startsWith(SC_PREFIX)).length;
-  const s = all[HIT_STATS_KEY] || { tcHits: 0, tcMisses: 0, scHits: 0, scMisses: 0 };
+  // entries 数と hit rate しか必要ないので prefix 別にキー数だけ数える。
+  // 全 storage 取得 → object 化 → filter よりキーだけ列挙する方が軽い。
+  let tcEntries = 0;
+  let scEntries = 0;
+  if (typeof chrome.storage.local.getKeys === 'function') {
+    const allKeys = await chrome.storage.local.getKeys();
+    for (const k of allKeys) {
+      if (k.startsWith(TC_PREFIX)) tcEntries++;
+      else if (k.startsWith(SC_PREFIX)) scEntries++;
+    }
+  } else {
+    const all = await storageGet(null);
+    for (const k of Object.keys(all)) {
+      if (k.startsWith(TC_PREFIX)) tcEntries++;
+      else if (k.startsWith(SC_PREFIX)) scEntries++;
+    }
+  }
+  const data = await storageGet(HIT_STATS_KEY);
+  const s = data[HIT_STATS_KEY] || { tcHits: 0, tcMisses: 0, scHits: 0, scMisses: 0 };
   return {
     tcEntries,
     scEntries,

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -264,6 +264,22 @@ describe('mapWithConcurrency()', () => {
   });
 });
 
+describe('getEngineConfig() キャッシュ化（#176）', () => {
+  // Issue #176: ホットパス（翻訳メッセージごと）の storage IO を削減するため、
+  // モジュールキャッシュ + onChanged invalidate の構造に変更。挙動のソースガード。
+  it('content の getEngineConfig が engineConfigCache を参照する形になっている', () => {
+    expect(code).toMatch(/let\s+engineConfigCache\s*=\s*null/);
+    expect(code).toMatch(/if\s*\(engineConfigCache\)\s*return\s+engineConfigCache/);
+  });
+
+  it('chrome.storage.onChanged で関連キー変更時に engineConfigCache を invalidate する', () => {
+    expect(code).toMatch(/chrome\.storage\.onChanged\.addListener/);
+    // ENGINE_CONFIG_KEYS のいずれかが変わったら null 化する経路が存在
+    expect(code).toMatch(/ENGINE_CONFIG_KEYS\.some/);
+    expect(code).toMatch(/engineConfigCache\s*=\s*null/);
+  });
+});
+
 describe('isNetworkError()', () => {
   it('TypeError + "Failed to fetch" は network error 扱い（fetch ネットワーク不通の典型）', () => {
     expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -267,9 +267,9 @@ describe('mapWithConcurrency()', () => {
 describe('getEngineConfig() キャッシュ化（#176）', () => {
   // Issue #176: ホットパス（翻訳メッセージごと）の storage IO を削減するため、
   // モジュールキャッシュ + onChanged invalidate の構造に変更。挙動のソースガード。
-  it('content の getEngineConfig が engineConfigCache を参照する形になっている', () => {
+  it('background の getEngineConfig が engineConfigCache を参照する形になっている', () => {
     expect(code).toMatch(/let\s+engineConfigCache\s*=\s*null/);
-    expect(code).toMatch(/if\s*\(engineConfigCache\)\s*return\s+engineConfigCache/);
+    expect(code).toMatch(/if\s*\(!engineConfigCache\)/);
   });
 
   it('chrome.storage.onChanged で関連キー変更時に engineConfigCache を invalidate する', () => {

--- a/tests/translation-cache.test.js
+++ b/tests/translation-cache.test.js
@@ -14,10 +14,10 @@ function loadCacheModule() {
     'SC_PREFIX', 'SC_MAX_ENTRIES', 'SC_TTL_MS', 'SC_EVICT_RATIO',
     'HIT_STATS_KEY', 'CLAUDE_SUMMARY_MODEL',
     '_hitStatsQueue',
-    'storageGet', 'storageSet', 'storageRemove',
+    'storageGet', 'storageSet', 'storageRemove', 'storageGetKeys',
     'recordCacheAccess', 'calcHitRate',
     'hashText', 'buildCacheKey', 'buildSummaryCacheKey', 'getCached', 'setCached',
-    'getCacheEntriesByPrefix',
+    'getCacheEntriesByPrefix', 'pickEntriesByPrefix', 'evictEntries',
     'evictByPrefix', 'evictIfNeeded', 'clearCache', 'getCacheStats',
   ];
   const defs = names.map(n => {

--- a/tests/translation-cache.test.js
+++ b/tests/translation-cache.test.js
@@ -17,6 +17,7 @@ function loadCacheModule() {
     'storageGet', 'storageSet', 'storageRemove',
     'recordCacheAccess', 'calcHitRate',
     'hashText', 'buildCacheKey', 'buildSummaryCacheKey', 'getCached', 'setCached',
+    'getCacheEntriesByPrefix',
     'evictByPrefix', 'evictIfNeeded', 'clearCache', 'getCacheStats',
   ];
   const defs = names.map(n => {


### PR DESCRIPTION
## Summary

\`/skill simplify\` のレビューで **HIGH** 指摘の出ていたホットパス効率化 2 件に対応。

## 変更内容

### A. \`getEngineConfig\` のモジュールキャッシュ化

ページ全体翻訳・MutationObserver 連動翻訳では 1 セッションで数十〜数百要素を並行翻訳する。`fetchTranslation` 内で毎回 `chrome.storage.local.get(['translateEngine', 'deeplApiKey', 'appleAvailable'])` を走らせていたため storage IO が多重発生。

\`\`\`js
let engineConfigCache = null;
const ENGINE_CONFIG_KEYS = ['translateEngine', 'deeplApiKey', 'appleAvailable'];

async function getEngineConfig() {
  if (engineConfigCache) return engineConfigCache;
  engineConfigCache = await loadEngineConfig();
  return engineConfigCache;
}

chrome.storage.onChanged.addListener((changes) => {
  if (ENGINE_CONFIG_KEYS.some((k) => k in changes)) {
    engineConfigCache = null;
  }
});
\`\`\`

100 要素一括翻訳で **storage read 100 回 → 1 回**に。

### B. \`evictByPrefix\` / \`clearCache\` / \`getCacheStats\` を prefix-only 取得に

既存実装は \`storageGet(null)\` で全エントリ取得していたため、自動翻訳ルール・設定値等まで毎回シリアライズされていた。

- **\`getCacheEntriesByPrefix(prefix)\` ヘルパー追加**:
  - \`chrome.storage.local.getKeys()\` があればキー一覧だけ取得 → 必要分のみ get
  - 無ければ \`get(null)\` フォールバック（既存挙動維持）
- **\`evictByPrefix\` シグネチャ変更**: \`(all, prefix, ...)\` → \`(prefix, ...)\`
- **\`getCacheStats\`**: キー数を数えるだけなので getKeys() でさらに軽量化

## 期待効果

- **A**: 翻訳ホットパスの storage IO を 1 セッション 1 回に圧縮
- **B**: \`setCached\` 5% 確率の evict 発火時の評価コスト削減（大規模 storage で体感差）
- 大規模ユーザー（自動翻訳ルール多数 + キャッシュ満杯）で特に効果大

## 検証

- \`npm test\`: **488/488 passed**（既存 486 + getEngineConfig キャッシュ構造の source ガード 2）
- \`tests/translation-cache.test.js\` の eval 抽出に \`getCacheEntriesByPrefix\` を追加し、既存の evict / clearCache テスト全件パスを維持
- 挙動変化なし（読み取りパスの最適化のみ）

## 残ラウンド

- Round 4: Swift 側整理（availability ヘルパー / HiddenHostHolder.window.close 等）

closes #176