### PR TITLE
feat: Container App 起動画面を 11 言語に多言語化（#188）

### DIFF
--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -1644,3 +1644,58 @@ suites:
         expected:
           - "Base.lproj/MainInterface.storyboard / Base.lproj/ShareViewController.xib が存在しない"
           - 各フォルダに Swift ファイル 5 個（ShareViewController + ShareAppGroup + TranslationProviderGoogle + I18N + SharedTranslationView）が存在
+
+  # ━━━━━ N+6. Container App 起動画面の多言語化（Issue #188） ━━━━━
+  - id: container-app-i18n
+    title: iOS / macOS Container App 起動画面の多言語化
+    description: "PR #189 で `Shared (App)/Resources/Script.js` に 11 言語辞書を追加し、`navigator.language` に応じて Main.html のテキストを書き換えるようにした"
+    related_prs: [189]
+    scenarios:
+
+      - id: CAI-001
+        title: 端末の言語を日本語にすると Container App が日本語で表示される
+        priority: p1
+        environment: safari-ios-sim / safari-mac
+        steps:
+          - 端末（または Simulator）の言語設定を「日本語」に変更
+          - DualView Translator の Container App を起動
+        expected:
+          - "iOS: 「Safari の設定から DualView Translator 拡張を有効にしてください。」と表示"
+          - "macOS（拡張状態 unknown）: 「Safari の機能拡張設定から…」と表示"
+          - "macOS（macOS 13+）: 「Safari の設定 → 機能拡張から…」と表示"
+
+      - id: CAI-002
+        title: 11 言語のうち他の主要言語でも切替できる
+        priority: p2
+        environment: safari-ios-sim / safari-mac
+        steps:
+          - 端末言語を順に en / zh-CN / zh-TW / ko / fr / de / es / pt / ru / ar に変更
+          - 各言語で Container App を起動
+        expected:
+          - 各言語の翻訳テキストが表示される
+          - 'ar の場合は HTML の `dir="rtl"` で右→左レイアウト'
+          - "未対応言語（例: it = Italian）に切替えた場合は en にフォールバック"
+
+      - id: CAI-003
+        title: 拡張 ON/OFF 状態に応じて文言が切り替わる（macOS）
+        priority: p2
+        environment: safari-mac
+        steps:
+          - macOS Safari で拡張を有効化
+          - Container App を再起動
+          - Safari で拡張を無効化
+          - Container App を再起動
+        expected:
+          - 有効時 「DualView Translator 拡張は現在オンです。…」（または各言語版）
+          - 無効時 「DualView Translator 拡張は現在オフです。…」（または各言語版）
+          - 未判定時は unknown 用の文言
+
+      - id: CAI-004
+        title: macOS の Quit and Open ボタンも翻訳される
+        priority: p2
+        environment: safari-mac
+        steps:
+          - 言語を日本語に切替えて Container App を macOS で起動
+        expected:
+          - ボタン文言が「終了して Safari の機能拡張設定を開く…」に切り替わる
+          - macOS Sequoia 以降では「終了して Safari の設定を開く…」に切り替わる

--- a/safari/DualView Translator/Shared (App)/Resources/Base.lproj/Main.html
+++ b/safari/DualView Translator/Shared (App)/Resources/Base.lproj/Main.html
@@ -11,10 +11,10 @@
 </head>
 <body>
     <img src="../Icon.png" width="128" height="128" alt="DualView Translator Icon">
-    <p class="platform-ios">You can turn on DualView Translator’s Safari extension in Settings.</p>
-    <p class="platform-mac state-unknown">You can turn on DualView Translator’s extension in Safari Extensions preferences.</p>
-    <p class="platform-mac state-on">DualView Translator’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
-    <p class="platform-mac state-off">DualView Translator’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
-    <button class="platform-mac open-preferences">Quit and Open Safari Extensions Preferences…</button>
+    <p class="platform-ios" data-i18n="iosEnable">You can turn on DualView Translator’s Safari extension in Settings.</p>
+    <p class="platform-mac state-unknown" data-i18n="macUnknown">You can turn on DualView Translator’s extension in Safari Extensions preferences.</p>
+    <p class="platform-mac state-on" data-i18n="macOn">DualView Translator’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
+    <p class="platform-mac state-off" data-i18n="macOff">DualView Translator’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
+    <button class="platform-mac open-preferences" data-i18n="openPreferencesBtn">Quit and Open Safari Extensions Preferences…</button>
 </body>
 </html>

--- a/safari/DualView Translator/Shared (App)/Resources/Script.js
+++ b/safari/DualView Translator/Shared (App)/Resources/Script.js
@@ -1,12 +1,181 @@
+// Copyright (c) Orangesoft Inc.
+// DualView Translator — Container App の Safari 拡張案内画面（Main.html）の i18n + 状態切替
+
+// ─── i18n 辞書 ────────────────────────────────────────────────────────
+// 拡張本体の i18n.js と同じ 11 言語。キー名は Container App 専用なので別管理。
+// キーを追加・変更したら Main.html の data-i18n 属性も同期して更新する。
+const I18N_MESSAGES = {
+    "ja": {
+        iosEnable:               "Safari の設定から DualView Translator 拡張を有効にしてください。",
+        macUnknown:              "Safari の機能拡張設定から DualView Translator 拡張を有効にしてください。",
+        macUnknownSettings:      "Safari の設定 → 機能拡張から DualView Translator 拡張を有効にしてください。",
+        macOn:                   "DualView Translator 拡張は現在オンです。Safari の機能拡張設定からオフにできます。",
+        macOnSettings:           "DualView Translator 拡張は現在オンです。Safari の設定 → 機能拡張からオフにできます。",
+        macOff:                  "DualView Translator 拡張は現在オフです。Safari の機能拡張設定からオンにできます。",
+        macOffSettings:          "DualView Translator 拡張は現在オフです。Safari の設定 → 機能拡張からオンにできます。",
+        openPreferencesBtn:      "終了して Safari の機能拡張設定を開く…",
+        openSettingsBtn:         "終了して Safari の設定を開く…",
+    },
+    "en": {
+        iosEnable:               "You can turn on DualView Translator’s Safari extension in Settings.",
+        macUnknown:              "You can turn on DualView Translator’s extension in Safari Extensions preferences.",
+        macUnknownSettings:      "You can turn on DualView Translator’s extension in the Extensions section of Safari Settings.",
+        macOn:                   "DualView Translator’s extension is currently on. You can turn it off in Safari Extensions preferences.",
+        macOnSettings:           "DualView Translator’s extension is currently on. You can turn it off in the Extensions section of Safari Settings.",
+        macOff:                  "DualView Translator’s extension is currently off. You can turn it on in Safari Extensions preferences.",
+        macOffSettings:          "DualView Translator’s extension is currently off. You can turn it on in the Extensions section of Safari Settings.",
+        openPreferencesBtn:      "Quit and Open Safari Extensions Preferences…",
+        openSettingsBtn:         "Quit and Open Safari Settings…",
+    },
+    "zh-CN": {
+        iosEnable:               "请在 Safari 设置中启用 DualView Translator 扩展。",
+        macUnknown:              "请在 Safari 扩展设置中启用 DualView Translator 扩展。",
+        macUnknownSettings:      "请在 Safari 设置 → 扩展中启用 DualView Translator 扩展。",
+        macOn:                   "DualView Translator 扩展当前已启用。可在 Safari 扩展设置中关闭。",
+        macOnSettings:           "DualView Translator 扩展当前已启用。可在 Safari 设置 → 扩展中关闭。",
+        macOff:                  "DualView Translator 扩展当前已关闭。可在 Safari 扩展设置中启用。",
+        macOffSettings:          "DualView Translator 扩展当前已关闭。可在 Safari 设置 → 扩展中启用。",
+        openPreferencesBtn:      "退出并打开 Safari 扩展设置…",
+        openSettingsBtn:         "退出并打开 Safari 设置…",
+    },
+    "zh-TW": {
+        iosEnable:               "請在 Safari 設定中啟用 DualView Translator 擴充功能。",
+        macUnknown:              "請在 Safari 擴充功能設定中啟用 DualView Translator 擴充功能。",
+        macUnknownSettings:      "請在 Safari 設定 → 擴充功能中啟用 DualView Translator 擴充功能。",
+        macOn:                   "DualView Translator 擴充功能目前已啟用。可在 Safari 擴充功能設定中關閉。",
+        macOnSettings:           "DualView Translator 擴充功能目前已啟用。可在 Safari 設定 → 擴充功能中關閉。",
+        macOff:                  "DualView Translator 擴充功能目前已關閉。可在 Safari 擴充功能設定中啟用。",
+        macOffSettings:          "DualView Translator 擴充功能目前已關閉。可在 Safari 設定 → 擴充功能中啟用。",
+        openPreferencesBtn:      "結束並開啟 Safari 擴充功能設定…",
+        openSettingsBtn:         "結束並開啟 Safari 設定…",
+    },
+    "ko": {
+        iosEnable:               "Safari 설정에서 DualView Translator 확장 프로그램을 켤 수 있습니다.",
+        macUnknown:              "Safari 확장 프로그램 환경설정에서 DualView Translator 확장 프로그램을 켤 수 있습니다.",
+        macUnknownSettings:      "Safari 설정의 확장 프로그램 섹션에서 DualView Translator 확장 프로그램을 켤 수 있습니다.",
+        macOn:                   "DualView Translator 확장 프로그램이 현재 켜져 있습니다. Safari 확장 프로그램 환경설정에서 끌 수 있습니다.",
+        macOnSettings:           "DualView Translator 확장 프로그램이 현재 켜져 있습니다. Safari 설정의 확장 프로그램 섹션에서 끌 수 있습니다.",
+        macOff:                  "DualView Translator 확장 프로그램이 현재 꺼져 있습니다. Safari 확장 프로그램 환경설정에서 켤 수 있습니다.",
+        macOffSettings:          "DualView Translator 확장 프로그램이 현재 꺼져 있습니다. Safari 설정의 확장 프로그램 섹션에서 켤 수 있습니다.",
+        openPreferencesBtn:      "종료하고 Safari 확장 프로그램 환경설정 열기…",
+        openSettingsBtn:         "종료하고 Safari 설정 열기…",
+    },
+    "fr": {
+        iosEnable:               "Vous pouvez activer l’extension Safari DualView Translator dans Réglages.",
+        macUnknown:              "Vous pouvez activer l’extension DualView Translator dans les préférences des extensions Safari.",
+        macUnknownSettings:      "Vous pouvez activer l’extension DualView Translator dans la section Extensions des Réglages de Safari.",
+        macOn:                   "L’extension DualView Translator est actuellement activée. Vous pouvez la désactiver dans les préférences des extensions Safari.",
+        macOnSettings:           "L’extension DualView Translator est actuellement activée. Vous pouvez la désactiver dans la section Extensions des Réglages de Safari.",
+        macOff:                  "L’extension DualView Translator est actuellement désactivée. Vous pouvez l’activer dans les préférences des extensions Safari.",
+        macOffSettings:          "L’extension DualView Translator est actuellement désactivée. Vous pouvez l’activer dans la section Extensions des Réglages de Safari.",
+        openPreferencesBtn:      "Quitter et ouvrir les préférences des extensions Safari…",
+        openSettingsBtn:         "Quitter et ouvrir les Réglages de Safari…",
+    },
+    "de": {
+        iosEnable:               "Sie können die Safari-Erweiterung von DualView Translator in den Einstellungen aktivieren.",
+        macUnknown:              "Sie können die DualView Translator-Erweiterung in den Safari-Erweiterungseinstellungen aktivieren.",
+        macUnknownSettings:      "Sie können die DualView Translator-Erweiterung im Bereich „Erweiterungen“ der Safari-Einstellungen aktivieren.",
+        macOn:                   "Die DualView Translator-Erweiterung ist derzeit aktiviert. Sie können sie in den Safari-Erweiterungseinstellungen deaktivieren.",
+        macOnSettings:           "Die DualView Translator-Erweiterung ist derzeit aktiviert. Sie können sie im Bereich „Erweiterungen“ der Safari-Einstellungen deaktivieren.",
+        macOff:                  "Die DualView Translator-Erweiterung ist derzeit deaktiviert. Sie können sie in den Safari-Erweiterungseinstellungen aktivieren.",
+        macOffSettings:          "Die DualView Translator-Erweiterung ist derzeit deaktiviert. Sie können sie im Bereich „Erweiterungen“ der Safari-Einstellungen aktivieren.",
+        openPreferencesBtn:      "Beenden und Safari-Erweiterungseinstellungen öffnen…",
+        openSettingsBtn:         "Beenden und Safari-Einstellungen öffnen…",
+    },
+    "es": {
+        iosEnable:               "Puedes activar la extensión de Safari DualView Translator en Ajustes.",
+        macUnknown:              "Puedes activar la extensión DualView Translator en las preferencias de extensiones de Safari.",
+        macUnknownSettings:      "Puedes activar la extensión DualView Translator en la sección Extensiones de los Ajustes de Safari.",
+        macOn:                   "La extensión DualView Translator está activada. Puedes desactivarla en las preferencias de extensiones de Safari.",
+        macOnSettings:           "La extensión DualView Translator está activada. Puedes desactivarla en la sección Extensiones de los Ajustes de Safari.",
+        macOff:                  "La extensión DualView Translator está desactivada. Puedes activarla en las preferencias de extensiones de Safari.",
+        macOffSettings:          "La extensión DualView Translator está desactivada. Puedes activarla en la sección Extensiones de los Ajustes de Safari.",
+        openPreferencesBtn:      "Salir y abrir las preferencias de extensiones de Safari…",
+        openSettingsBtn:         "Salir y abrir los Ajustes de Safari…",
+    },
+    "pt": {
+        iosEnable:               "Você pode ativar a extensão Safari do DualView Translator em Ajustes.",
+        macUnknown:              "Você pode ativar a extensão do DualView Translator nas preferências de extensões do Safari.",
+        macUnknownSettings:      "Você pode ativar a extensão do DualView Translator na seção Extensões dos Ajustes do Safari.",
+        macOn:                   "A extensão do DualView Translator está ativada. Você pode desativá-la nas preferências de extensões do Safari.",
+        macOnSettings:           "A extensão do DualView Translator está ativada. Você pode desativá-la na seção Extensões dos Ajustes do Safari.",
+        macOff:                  "A extensão do DualView Translator está desativada. Você pode ativá-la nas preferências de extensões do Safari.",
+        macOffSettings:          "A extensão do DualView Translator está desativada. Você pode ativá-la na seção Extensões dos Ajustes do Safari.",
+        openPreferencesBtn:      "Encerrar e abrir as preferências de extensões do Safari…",
+        openSettingsBtn:         "Encerrar e abrir os Ajustes do Safari…",
+    },
+    "ru": {
+        iosEnable:               "Вы можете включить расширение Safari DualView Translator в Настройках.",
+        macUnknown:              "Вы можете включить расширение DualView Translator в настройках расширений Safari.",
+        macUnknownSettings:      "Вы можете включить расширение DualView Translator в разделе «Расширения» Настроек Safari.",
+        macOn:                   "Расширение DualView Translator сейчас включено. Его можно отключить в настройках расширений Safari.",
+        macOnSettings:           "Расширение DualView Translator сейчас включено. Его можно отключить в разделе «Расширения» Настроек Safari.",
+        macOff:                  "Расширение DualView Translator сейчас выключено. Его можно включить в настройках расширений Safari.",
+        macOffSettings:          "Расширение DualView Translator сейчас выключено. Его можно включить в разделе «Расширения» Настроек Safari.",
+        openPreferencesBtn:      "Выйти и открыть настройки расширений Safari…",
+        openSettingsBtn:         "Выйти и открыть Настройки Safari…",
+    },
+    "ar": {
+        iosEnable:               "يمكنك تفعيل امتداد Safari الخاص بـ DualView Translator من الإعدادات.",
+        macUnknown:              "يمكنك تفعيل امتداد DualView Translator من تفضيلات امتدادات Safari.",
+        macUnknownSettings:      "يمكنك تفعيل امتداد DualView Translator من قسم الامتدادات في إعدادات Safari.",
+        macOn:                   "امتداد DualView Translator مفعَّل حاليًا. يمكنك إيقافه من تفضيلات امتدادات Safari.",
+        macOnSettings:           "امتداد DualView Translator مفعَّل حاليًا. يمكنك إيقافه من قسم الامتدادات في إعدادات Safari.",
+        macOff:                  "امتداد DualView Translator متوقف حاليًا. يمكنك تفعيله من تفضيلات امتدادات Safari.",
+        macOffSettings:          "امتداد DualView Translator متوقف حاليًا. يمكنك تفعيله من قسم الامتدادات في إعدادات Safari.",
+        openPreferencesBtn:      "إنهاء وفتح تفضيلات امتدادات Safari…",
+        openSettingsBtn:         "إنهاء وفتح إعدادات Safari…",
+    },
+};
+
+// 端末ロケールを 11 言語のいずれかに正規化する。
+// macOS は "zh-Hans-JP" のように Hans/Hant suffix を付けるので、その分解にも対応。
+function resolveLang() {
+    const raw = (navigator.language || "en").toLowerCase().replace(/_/g, "-");
+    if (I18N_MESSAGES[raw]) return raw;
+    const base = raw.split("-")[0];
+    if (I18N_MESSAGES[base]) return base;
+    if (raw.startsWith("zh")) {
+        return raw.includes("hant") || raw.includes("tw") ? "zh-TW" : "zh-CN";
+    }
+    return "en";
+}
+
+// data-i18n 属性に対応するメッセージを反映する。
+// settings 表記用キー（macUnknownSettings 等）は useSettingsInsteadOfPreferences のときに上書きする。
+function applyI18n(useSettingsInsteadOfPreferences) {
+    const lang = resolveLang();
+    const fallback = I18N_MESSAGES["en"];
+    const table = I18N_MESSAGES[lang] || fallback;
+
+    // RTL 切替（アラビア語）
+    if (lang === "ar") {
+        document.documentElement.dir = "rtl";
+        document.documentElement.lang = "ar";
+    } else {
+        document.documentElement.dir = "ltr";
+        document.documentElement.lang = lang;
+    }
+
+    document.querySelectorAll("[data-i18n]").forEach((el) => {
+        const baseKey = el.getAttribute("data-i18n");
+        // useSettingsInsteadOfPreferences が true のときは "<baseKey>Settings" 版を優先
+        const settingsKey = baseKey + "Settings";
+        let key = baseKey;
+        if (useSettingsInsteadOfPreferences && (table[settingsKey] || fallback[settingsKey])) {
+            key = settingsKey;
+        }
+        const text = table[key] || fallback[key];
+        if (text) el.textContent = text;
+    });
+}
+
+// SafariWebExtensionHandler / ViewController から呼ばれるエントリーポイント
 function show(platform, enabled, useSettingsInsteadOfPreferences) {
     document.body.classList.add(`platform-${platform}`);
 
-    if (useSettingsInsteadOfPreferences) {
-        document.getElementsByClassName('platform-mac state-on')[0].innerText = "DualView Translator’s extension is currently on. You can turn it off in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('platform-mac state-off')[0].innerText = "DualView Translator’s extension is currently off. You can turn it on in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('platform-mac state-unknown')[0].innerText = "You can turn on DualView Translator’s extension in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('platform-mac open-preferences')[0].innerText = "Quit and Open Safari Settings…";
-    }
+    // 言語に応じてテキストを差し替え（既存の useSettingsInsteadOfPreferences 切替も統合）
+    applyI18n(useSettingsInsteadOfPreferences);
 
     if (typeof enabled === "boolean") {
         document.body.classList.toggle(`state-on`, enabled);
@@ -22,3 +191,8 @@ function openPreferences() {
 }
 
 document.querySelector("button.open-preferences").addEventListener("click", openPreferences);
+
+// show() 経由で applyI18n が呼ばれるが、Native 側から show() がまだ呼ばれていない初期描画時にも
+// 端末ロケールでテキストを表示しておきたいので、DOMContentLoaded で 1 回適用する。
+// （show() がその後呼ばれた時に再度同じ言語で書き換えるが冪等）
+document.addEventListener("DOMContentLoaded", () => applyI18n(false));

--- a/safari/DualView Translator/Shared (App)/Resources/Script.js
+++ b/safari/DualView Translator/Shared (App)/Resources/Script.js
@@ -14,7 +14,7 @@ const I18N_MESSAGES = {
         macOff:                  "DualView Translator 拡張は現在オフです。Safari の機能拡張設定からオンにできます。",
         macOffSettings:          "DualView Translator 拡張は現在オフです。Safari の設定 → 機能拡張からオンにできます。",
         openPreferencesBtn:      "終了して Safari の機能拡張設定を開く…",
-        openSettingsBtn:         "終了して Safari の設定を開く…",
+        openPreferencesBtnSettings: "終了して Safari の設定を開く…",
     },
     "en": {
         iosEnable:               "You can turn on DualView Translator’s Safari extension in Settings.",
@@ -25,7 +25,7 @@ const I18N_MESSAGES = {
         macOff:                  "DualView Translator’s extension is currently off. You can turn it on in Safari Extensions preferences.",
         macOffSettings:          "DualView Translator’s extension is currently off. You can turn it on in the Extensions section of Safari Settings.",
         openPreferencesBtn:      "Quit and Open Safari Extensions Preferences…",
-        openSettingsBtn:         "Quit and Open Safari Settings…",
+        openPreferencesBtnSettings: "Quit and Open Safari Settings…",
     },
     "zh-CN": {
         iosEnable:               "请在 Safari 设置中启用 DualView Translator 扩展。",
@@ -36,7 +36,7 @@ const I18N_MESSAGES = {
         macOff:                  "DualView Translator 扩展当前已关闭。可在 Safari 扩展设置中启用。",
         macOffSettings:          "DualView Translator 扩展当前已关闭。可在 Safari 设置 → 扩展中启用。",
         openPreferencesBtn:      "退出并打开 Safari 扩展设置…",
-        openSettingsBtn:         "退出并打开 Safari 设置…",
+        openPreferencesBtnSettings: "退出并打开 Safari 设置…",
     },
     "zh-TW": {
         iosEnable:               "請在 Safari 設定中啟用 DualView Translator 擴充功能。",
@@ -47,7 +47,7 @@ const I18N_MESSAGES = {
         macOff:                  "DualView Translator 擴充功能目前已關閉。可在 Safari 擴充功能設定中啟用。",
         macOffSettings:          "DualView Translator 擴充功能目前已關閉。可在 Safari 設定 → 擴充功能中啟用。",
         openPreferencesBtn:      "結束並開啟 Safari 擴充功能設定…",
-        openSettingsBtn:         "結束並開啟 Safari 設定…",
+        openPreferencesBtnSettings: "結束並開啟 Safari 設定…",
     },
     "ko": {
         iosEnable:               "Safari 설정에서 DualView Translator 확장 프로그램을 켤 수 있습니다.",
@@ -58,7 +58,7 @@ const I18N_MESSAGES = {
         macOff:                  "DualView Translator 확장 프로그램이 현재 꺼져 있습니다. Safari 확장 프로그램 환경설정에서 켤 수 있습니다.",
         macOffSettings:          "DualView Translator 확장 프로그램이 현재 꺼져 있습니다. Safari 설정의 확장 프로그램 섹션에서 켤 수 있습니다.",
         openPreferencesBtn:      "종료하고 Safari 확장 프로그램 환경설정 열기…",
-        openSettingsBtn:         "종료하고 Safari 설정 열기…",
+        openPreferencesBtnSettings: "종료하고 Safari 설정 열기…",
     },
     "fr": {
         iosEnable:               "Vous pouvez activer l’extension Safari DualView Translator dans Réglages.",
@@ -69,7 +69,7 @@ const I18N_MESSAGES = {
         macOff:                  "L’extension DualView Translator est actuellement désactivée. Vous pouvez l’activer dans les préférences des extensions Safari.",
         macOffSettings:          "L’extension DualView Translator est actuellement désactivée. Vous pouvez l’activer dans la section Extensions des Réglages de Safari.",
         openPreferencesBtn:      "Quitter et ouvrir les préférences des extensions Safari…",
-        openSettingsBtn:         "Quitter et ouvrir les Réglages de Safari…",
+        openPreferencesBtnSettings: "Quitter et ouvrir les Réglages de Safari…",
     },
     "de": {
         iosEnable:               "Sie können die Safari-Erweiterung von DualView Translator in den Einstellungen aktivieren.",
@@ -80,7 +80,7 @@ const I18N_MESSAGES = {
         macOff:                  "Die DualView Translator-Erweiterung ist derzeit deaktiviert. Sie können sie in den Safari-Erweiterungseinstellungen aktivieren.",
         macOffSettings:          "Die DualView Translator-Erweiterung ist derzeit deaktiviert. Sie können sie im Bereich „Erweiterungen“ der Safari-Einstellungen aktivieren.",
         openPreferencesBtn:      "Beenden und Safari-Erweiterungseinstellungen öffnen…",
-        openSettingsBtn:         "Beenden und Safari-Einstellungen öffnen…",
+        openPreferencesBtnSettings: "Beenden und Safari-Einstellungen öffnen…",
     },
     "es": {
         iosEnable:               "Puedes activar la extensión de Safari DualView Translator en Ajustes.",
@@ -91,7 +91,7 @@ const I18N_MESSAGES = {
         macOff:                  "La extensión DualView Translator está desactivada. Puedes activarla en las preferencias de extensiones de Safari.",
         macOffSettings:          "La extensión DualView Translator está desactivada. Puedes activarla en la sección Extensiones de los Ajustes de Safari.",
         openPreferencesBtn:      "Salir y abrir las preferencias de extensiones de Safari…",
-        openSettingsBtn:         "Salir y abrir los Ajustes de Safari…",
+        openPreferencesBtnSettings: "Salir y abrir los Ajustes de Safari…",
     },
     "pt": {
         iosEnable:               "Você pode ativar a extensão Safari do DualView Translator em Ajustes.",
@@ -102,7 +102,7 @@ const I18N_MESSAGES = {
         macOff:                  "A extensão do DualView Translator está desativada. Você pode ativá-la nas preferências de extensões do Safari.",
         macOffSettings:          "A extensão do DualView Translator está desativada. Você pode ativá-la na seção Extensões dos Ajustes do Safari.",
         openPreferencesBtn:      "Encerrar e abrir as preferências de extensões do Safari…",
-        openSettingsBtn:         "Encerrar e abrir os Ajustes do Safari…",
+        openPreferencesBtnSettings: "Encerrar e abrir os Ajustes do Safari…",
     },
     "ru": {
         iosEnable:               "Вы можете включить расширение Safari DualView Translator в Настройках.",
@@ -113,7 +113,7 @@ const I18N_MESSAGES = {
         macOff:                  "Расширение DualView Translator сейчас выключено. Его можно включить в настройках расширений Safari.",
         macOffSettings:          "Расширение DualView Translator сейчас выключено. Его можно включить в разделе «Расширения» Настроек Safari.",
         openPreferencesBtn:      "Выйти и открыть настройки расширений Safari…",
-        openSettingsBtn:         "Выйти и открыть Настройки Safari…",
+        openPreferencesBtnSettings: "Выйти и открыть Настройки Safari…",
     },
     "ar": {
         iosEnable:               "يمكنك تفعيل امتداد Safari الخاص بـ DualView Translator من الإعدادات.",
@@ -124,7 +124,7 @@ const I18N_MESSAGES = {
         macOff:                  "امتداد DualView Translator متوقف حاليًا. يمكنك تفعيله من تفضيلات امتدادات Safari.",
         macOffSettings:          "امتداد DualView Translator متوقف حاليًا. يمكنك تفعيله من قسم الامتدادات في إعدادات Safari.",
         openPreferencesBtn:      "إنهاء وفتح تفضيلات امتدادات Safari…",
-        openSettingsBtn:         "إنهاء وفتح إعدادات Safari…",
+        openPreferencesBtnSettings: "إنهاء وفتح إعدادات Safari…",
     },
 };
 


### PR DESCRIPTION
## Summary

iOS / macOS の Container App 起動画面（Safari 拡張の有効化案内）が英語固定だったので、本拡張本体と同じ **11 言語**（ja / en / zh-CN / zh-TW / ko / fr / de / es / pt / ru / ar）に対応させた。

\`navigator.language\` 判定で表示言語を切替える JS ベースの i18n。Apple 標準の \`.lproj/\` ローカライズではないので **Xcode IDE 操作は不要**。

## Before / After

iOS / macOS の Container App 起動時、端末言語が日本語の場合:

| 元の表示 | 変更後 |
|---|---|
| You can turn on DualView Translator's Safari extension in Settings. | Safari の設定から DualView Translator 拡張を有効にしてください。 |

## 実装

### \`safari/DualView Translator/Shared (App)/Resources/Script.js\`

- \`I18N_MESSAGES\`: 11 言語 × 9 キーの辞書
  - iOS 用: \`iosEnable\`
  - macOS 用: \`macUnknown\` / \`macOn\` / \`macOff\` + 各 \`...Settings\` 版（macOS 13+ Sequoia 用）
  - ボタン: \`openPreferencesBtn\` / \`openSettingsBtn\`
- \`resolveLang()\`: \`navigator.language\` を 11 言語に正規化
  - macOS の \`zh-Hans-JP\` / \`zh-Hant-TW\` も \`zh-CN\` / \`zh-TW\` に解決
  - 大文字小文字差異・アンダースコア（\`_\`）も吸収
  - 未対応言語は \`en\` フォールバック
- \`applyI18n()\`: \`data-i18n\` 属性付き要素を一括書き換え
  - \`useSettingsInsteadOfPreferences\` が true なら \`<key>Settings\` 版を優先
  - アラビア語のとき \`document.documentElement.dir = \"rtl\"\` で RTL 切替
- \`DOMContentLoaded\` で初期描画時に 1 回適用 + Native の \`show()\` 経由でも再描画（冪等）

### \`safari/DualView Translator/Shared (App)/Resources/Base.lproj/Main.html\`

- 各 \`<p>\` / \`<button>\` に \`data-i18n=\"<key>\"\` を付与
- 初期表示テキスト（英語）はフォールバック用にそのまま維持

### \`docs/manual-test-scenarios.yaml\`

新スイート \`container-app-i18n\`（CAI-001〜CAI-004）を追加:

- 端末言語切替で日本語表示確認（p1）
- 11 言語の主要言語切替動作確認（p2）
- 拡張 ON/OFF 状態に応じた文言切替（macOS / p2）
- 「Quit and Open …」ボタンの翻訳確認（macOS / p2）

## 注意点

- ドイツ語の翻訳で `„...\"` のクオートを使う際、ASCII の `\"` だと JS パーサが文字列リテラルを途中で終了させてしまう問題があった。Unicode の `„` (U+201E) + `\"` (U+201C) に修正して解消
- 拡張本体の \`i18n.js\` とは別の辞書（Container App 専用キー）。共通化は将来の課題

## Test plan

- [x] \`npm test\`: **530 件全パス**（変化なし）
- [x] \`xcodebuild -scheme \"DualView Translator (macOS)\"\`: BUILD SUCCEEDED
- [x] \`xcodebuild -scheme \"DualView Translator (iOS)\"\`: BUILD SUCCEEDED
- [ ] 手動 CAI-001: iOS シミュレータで言語を日本語に → Container App 起動 → 日本語表示
- [ ] 手動 CAI-002: 11 言語の主要パスで切替確認
- [ ] 手動 CAI-003: 拡張 ON/OFF 状態の文言切替（macOS）

closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)