### PR TITLE
chore: v1.6.1 パッチリリース準備（#190）

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -12,6 +12,18 @@ permalink: /RELEASE_NOTES.en.html
 
 ---
 
+## v1.6.1 (2026-05-07)
+
+### Improvements
+
+- **Container app startup screen is now localized** (#188 / PR #189)
+  - The Safari-extension-enable prompt you see when you launch the iOS / macOS container app used to be English-only. Now it follows your device language across all 11 supported languages (ja / en / zh-CN / zh-TW / ko / fr / de / es / pt / ru / ar).
+  - The on/off state messages are localized too.
+  - macOS Sequoia's "Safari Settings → Extensions" wording is handled.
+  - Arabic gets automatic right-to-left layout.
+
+---
+
 ## v1.6.0 (2026-05-07)
 
 ### New features

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,6 +12,19 @@ permalink: /RELEASE_NOTES.html
 
 ---
 
+## v1.6.1（2026-05-07）
+
+### 改善
+
+- **Container App 起動画面の多言語化**（#188 / PR #189）
+  - iOS / macOS の Container App を起動したときに表示される Safari 拡張の有効化案内が、これまで英語固定だったのを 11 言語（ja / en / zh-CN / zh-TW / ko / fr / de / es / pt / ru / ar）に対応
+  - 端末の言語設定に応じて自動切替（`navigator.language` 判定）
+  - 拡張のオン/オフ状態に応じた説明文も全言語で表示
+  - macOS Sequoia 以降の「Safari の設定 → 機能拡張」表記にも対応
+  - アラビア語のときは右→左レイアウトに自動切替
+
+---
+
 ## v1.6.0（2026-05-07）
 
 ### 新機能

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "DualView Translator",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dualview-translator",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox 対応。",
   "main": "background.js",
   "directories": {

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -866,7 +866,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -878,7 +878,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -901,7 +901,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -913,7 +913,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -939,7 +939,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -982,7 +982,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -998,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1024,7 +1024,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1049,7 +1049,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1097,7 +1097,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1122,7 +1122,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1140,7 +1140,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1185,7 +1185,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1210,7 +1210,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (iOS)/DualView Share Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DualView Share Extension (iOS)/Info.plist";
@@ -1222,7 +1222,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1241,7 +1241,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (iOS)/DualView Share Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DualView Share Extension (iOS)/Info.plist";
@@ -1253,7 +1253,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1274,7 +1274,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (macOS)/DualView Share Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1288,7 +1288,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1308,7 +1308,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (macOS)/DualView Share Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1322,7 +1322,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

v1.6.0 リリース後に main に取り込んだ **Container App 起動画面の i18n**（#188 / PR #189）をパッチリリース **v1.6.1** として配布するためのバージョン更新。

新機能はなく、ユーザー可視の差分は「iOS / macOS Container App の Safari 拡張案内画面が 11 言語で表示される」のみ。

## バージョン

- v1.6.0 → **v1.6.1**
- build 6 → 7

## 変更

| ファイル | 内容 |
|---|---|
| \`manifest.json\` / \`package.json\` | version 1.6.1 |
| \`project.pbxproj\` | \`MARKETING_VERSION\` 12 箇所 + \`CURRENT_PROJECT_VERSION\` 12 箇所 |
| \`docs/RELEASE_NOTES.md\` / \`.en.md\` | **v1.6.1（2026-05-07）** セクション |

## Test plan

- [x] \`npm test\`: **530 件全パス**
- [x] \`xcodebuild -scheme \"DualView Translator (macOS)\"\`: BUILD SUCCEEDED
- [x] \`xcodebuild -scheme \"DualView Translator (iOS)\"\`: BUILD SUCCEEDED
- [x] \`grep -c \"MARKETING_VERSION = 1.6.1;\" project.pbxproj\` = **12**
- [x] \`grep -c \"CURRENT_PROJECT_VERSION = 7;\" project.pbxproj\` = **12**

## マージ後の人間タスク

| やること | 担当 |
|---|---|
| \`v1.6.1\` タグ + GitHub Release | \`/release\` スキル |
| \`/build-zip\` で zip 生成 | スキル |
| Chrome Web Store にアップロード | 人間 |
| Firefox AMO にアップロード | 人間 |
| App Store Connect: TestFlight ビルドアップロード | Xcode / 人間 |
| App Store 提出（v1.6.1 アップデート） | 人間 |

## App Store 提出時の注意

v1.6.1 はパッチリリースで、**新機能（Share Extension 等）の追加はない**。前回 v1.6.0 提出時にレビューされた内容と本質的に変わらないため、審査が早く通る可能性があります。

closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)