### PR TITLE
fix: Share Extension の PRODUCT_NAME からカッコを除去（v1.6.1 hotfix）

### DIFF
--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -1224,7 +1224,7 @@
 				);
 				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "DualView Share Extension";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1255,7 +1255,7 @@
 				);
 				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "DualView Share Extension";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1290,7 +1290,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "DualView Share Extension";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1324,7 +1324,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "DualView Share Extension";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<true/>
+</dict>
+</plist>

--- a/safari/DualView Translator/DualView Translator.xcodeproj/xcshareddata/xcschemes/DualView Share Extension (iOS).xcscheme
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/xcshareddata/xcschemes/DualView Share Extension (iOS).xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7DAFD3602FAC1B230017615B"
+               BuildableName = "DualView Share Extension.appex"
+               BlueprintName = "DualView Share Extension (iOS)"
+               ReferencedContainer = "container:DualView Translator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7D1D47D12F95AD9500B65F5F"
+               BuildableName = "DualView Translator.app"
+               BlueprintName = "DualView Translator (iOS)"
+               ReferencedContainer = "container:DualView Translator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D1D47D12F95AD9500B65F5F"
+            BuildableName = "DualView Translator.app"
+            BlueprintName = "DualView Translator (iOS)"
+            ReferencedContainer = "container:DualView Translator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D1D47D12F95AD9500B65F5F"
+            BuildableName = "DualView Translator.app"
+            BlueprintName = "DualView Translator (iOS)"
+            ReferencedContainer = "container:DualView Translator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/safari/DualView Translator/DualView Translator.xcodeproj/xcshareddata/xcschemes/DualView Share Extension (macOS).xcscheme
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/xcshareddata/xcschemes/DualView Share Extension (macOS).xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7DAFD3732FAC1B7C0017615B"
+               BuildableName = "DualView Share Extension.appex"
+               BlueprintName = "DualView Share Extension (macOS)"
+               ReferencedContainer = "container:DualView Translator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7D1D47E32F95AD9500B65F5F"
+               BuildableName = "DualView Translator.app"
+               BlueprintName = "DualView Translator (macOS)"
+               ReferencedContainer = "container:DualView Translator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D1D47E32F95AD9500B65F5F"
+            BuildableName = "DualView Translator.app"
+            BlueprintName = "DualView Translator (macOS)"
+            ReferencedContainer = "container:DualView Translator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D1D47E32F95AD9500B65F5F"
+            BuildableName = "DualView Translator.app"
+            BlueprintName = "DualView Translator (macOS)"
+            ReferencedContainer = "container:DualView Translator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary

App Store Connect / TestFlight への v1.6.1 アップロードが Apple の Validation エラーで拒否される問題の **緊急 hotfix**。

```
The server's response was: '{
    code = 90121;
    description = "Invalid Info.plist value. The CFBundleExecutable Info.plist key contains the DualView Share Extension (iOS) value in the "Payload/DualView Translator.app/PlugIns/DualView Share Extension (iOS).appex" bundle. This key's value can't contain any of the following unsupported characters: \ [ ] { } ( ) + *";
}'
```

## 原因

\`project.pbxproj\` の Share Extension 4 設定（iOS Debug/Release + macOS Debug/Release）で:

```
PRODUCT_NAME = "$(TARGET_NAME)";
```

となっており、\`TARGET_NAME\` が \`"DualView Share Extension (iOS)"\` / \`"(macOS)"\` のため **カッコ \`(\` \`)\` が CFBundleExecutable に流れて Apple の Validation で弾かれていた**。

## 修正

\`PRODUCT_NAME\` を \`"DualView Share Extension"\` にハードコード（4 箇所）。プラットフォーム suffix とカッコを除去した。

これは既存の Web Extension と同じパターン:

| ターゲット | PRODUCT_NAME | Bundle ID |
|---|---|---|
| DualView Translator Extension (iOS / macOS) | \`DualView Translator Extension\` | \`...Extension\` |
| DualView Share Extension (iOS / macOS)（本 PR） | \`DualView Share Extension\` | \`...ShareExtension\` |

iOS / macOS で同じ PRODUCT_NAME でも、別ターゲットで別 \`.appex\` が生成されるので問題なし。

## Test plan

- [x] \`xcodebuild -scheme \"DualView Translator (macOS)\"\`: BUILD SUCCEEDED
- [x] \`xcodebuild -scheme \"DualView Translator (iOS)\"\`: BUILD SUCCEEDED
- [x] \`grep -c 'PRODUCT_NAME = \"DualView Share Extension\"' project.pbxproj\` = **4**
- [x] \`grep -c 'PRODUCT_NAME = \"\$(TARGET_NAME)\"' project.pbxproj\` = **0**

## マージ後

1. **Xcode で再 Archive**: PRODUCT_NAME 変更を反映するため、できれば事前に **Product → Clean Build Folder** してから Archive
2. **TestFlight に再アップロード**:
   - \`CURRENT_PROJECT_VERSION\` は **build 7 のまま** で OK（Apple のサーバー側では前回の build 7 が validation 段階で拒否されており未登録扱い）
   - もし Xcode が build 番号の重複を警告する場合は **build 8** に上げて再 Archive
3. Validation を通過すれば TestFlight Processing に入る

## 補足: 副生成物について

xcodebuild で初めて Share Extension スキームをビルドした際に Xcode が自動生成した以下も含まれています:

- \`DualView Share Extension (iOS).xcscheme\`
- \`DualView Share Extension (macOS).xcscheme\`
- \`WorkspaceSettings.xcsettings\`

これらは Xcode のスキーム共有設定で、Project に含めて問題ないファイルです（Phase 2 で Xcode GUI からターゲット作成した際に shared としてマークされなかったために遅れて生成された）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)