### PR TITLE
chore: v1.6.2 パッチリリース準備（#193）

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -12,6 +12,17 @@ permalink: /RELEASE_NOTES.en.html
 
 ---
 
+## v1.6.2 (2026-05-07)
+
+### Bug fixes
+
+- **Fixed an App Store / TestFlight upload validation error** (PR #192 / #193)
+  - The Share Extension's `PRODUCT_NAME` carried platform suffixes (`(iOS)` / `(macOS)`), which leaked parentheses into `CFBundleExecutable` — Apple rejected uploads with error 90121.
+  - Hardcoded `PRODUCT_NAME` to `"DualView Share Extension"` (no parentheses) to resolve.
+  - No user-visible feature changes.
+
+---
+
 ## v1.6.1 (2026-05-07)
 
 ### Improvements

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,6 +12,17 @@ permalink: /RELEASE_NOTES.html
 
 ---
 
+## v1.6.2（2026-05-07）
+
+### バグ修正
+
+- **App Store / TestFlight アップロード時の Validation エラーを修正**（PR #192 / #193）
+  - Share Extension の `PRODUCT_NAME` がプラットフォーム suffix（`(iOS)` / `(macOS)`）を含んでおり、`CFBundleExecutable` のカッコ `( )` を Apple が拒否していた（error 90121）
+  - `PRODUCT_NAME` を `"DualView Share Extension"`（カッコなし）にハードコードして解消
+  - ユーザー可視の機能変更なし
+
+---
+
 ## v1.6.1（2026-05-07）
 
 ### 改善

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "DualView Translator",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dualview-translator",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox 対応。",
   "main": "background.js",
   "directories": {

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -866,7 +866,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -878,7 +878,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -901,7 +901,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -913,7 +913,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -939,7 +939,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -982,7 +982,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -998,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1024,7 +1024,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1049,7 +1049,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1097,7 +1097,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1122,7 +1122,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1140,7 +1140,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1185,7 +1185,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1210,7 +1210,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (iOS)/DualView Share Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DualView Share Extension (iOS)/Info.plist";
@@ -1222,7 +1222,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				SDKROOT = iphoneos;
@@ -1241,7 +1241,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (iOS)/DualView Share Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DualView Share Extension (iOS)/Info.plist";
@@ -1253,7 +1253,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				SDKROOT = iphoneos;
@@ -1274,7 +1274,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (macOS)/DualView Share Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1288,7 +1288,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				REGISTER_APP_GROUPS = YES;
@@ -1308,7 +1308,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (macOS)/DualView Share Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1322,7 +1322,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

PR #192 で修正した Share Extension の PRODUCT_NAME カッコ問題（App Store Validation error 90121）を **v1.6.2** として正式リリースするためのバージョン番号更新。

ユーザー可視の機能変更なし。**App Store / TestFlight にアップロード可能なビルドを生成する** ためのビルド番号更新が主目的。

## バージョン

- v1.6.1 → **v1.6.2**
- build 7 → **8**

## 変更

| ファイル | 内容 |
|---|---|
| \`manifest.json\` / \`package.json\` | version 1.6.2 |
| \`project.pbxproj\` | \`MARKETING_VERSION = 1.6.2\` 12 箇所 + \`CURRENT_PROJECT_VERSION = 8\` 12 箇所 |
| \`docs/RELEASE_NOTES.md\` / \`.en.md\` | **v1.6.2（2026-05-07）** セクション追加 |

## Test plan

- [x] \`npm test\`: **530 件全パス**
- [x] \`xcodebuild -scheme \"DualView Translator (macOS)\"\`: BUILD SUCCEEDED
- [x] \`xcodebuild -scheme \"DualView Translator (iOS)\"\`: BUILD SUCCEEDED
- [x] \`grep -c \"MARKETING_VERSION = 1.6.2;\" project.pbxproj\` = **12**
- [x] \`grep -c \"CURRENT_PROJECT_VERSION = 8;\" project.pbxproj\` = **12**

## マージ後

| やること | 担当 |
|---|---|
| \`v1.6.2\` タグ + GitHub Release（リリースノート転記）| Claude |
| 公開用 zip 作成（v1.6.2 として）| Claude |
| Chrome Web Store にアップロード | 人間 |
| Firefox AMO にアップロード | 人間 |
| Xcode Clean Build Folder + Archive（iOS / macOS）→ TestFlight アップロード | 人間 |
| App Store 提出 | 人間 |

closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)