### PR TITLE
fix: Apple翻訳失敗時のエラー詳細表示とiOS appleAvailableの誤判定を修正

### DIFF
--- a/background.js
+++ b/background.js
@@ -83,11 +83,14 @@ async function detectAppleAvailability() {
       nativePromise,
       new Promise((_, reject) => setTimeout(() => reject(new Error('ping timeout')), 3000)),
     ]);
-    // ping が ok:true でかつ Translation framework と LanguageAvailability API
-    // 両方が利用可能な OS でだけ apple を有効にする
+    // ping が ok:true でかつ Translation framework、LanguageAvailability API、
+    // そして translate アクション自体が実装済み（translateActionSupported）の場合のみ有効にする。
+    // translateActionSupported は macOS 15+ のみ true。iOS は Extension プロセスが
+    // UIWindowScene を持たないため translate アクション未実装（常に false）。
     const available = !!(response && response.ok &&
       response.translationFrameworkAvailable &&
-      response.languageAvailabilityAPIAvailable);
+      response.languageAvailabilityAPIAvailable &&
+      response.translateActionSupported);
     await chrome.storage.local.set({ appleAvailable: available });
     return available;
   } catch (_err) {

--- a/content-core.js
+++ b/content-core.js
@@ -55,7 +55,9 @@ var DVT = (function () {
           }
           resolve(res.result);
         } else {
-          resolve({ text: t('translateFailed'), detectedLang: null });
+          // res.error にネイティブハンドラや background.js からのエラー詳細が含まれる場合は表示する
+          const detail = res?.error ? ` — ${res.error}` : '';
+          resolve({ text: t('translateFailed') + detail, detectedLang: null });
         }
       });
     });

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -10,6 +10,12 @@ permalink: /RELEASE_NOTES.en.html
 
 ## Unreleased
 
+### Bug Fixes
+
+- **Apple Translation errors now show detail in the UI** (#202 / PR #203)
+  - Previously a failed translation just said `[Translation failed]` with no hint of why. Now the error message from the native handler is appended, so you can actually see what went wrong.
+  - Fixed a bug where `appleAvailable` was set to `true` on iOS Safari even though the `translate` action isn't implemented there (Extension processes don't have a UIWindowScene). The `ping` response now includes a `translateActionSupported` flag (`false` on iOS), so Apple Translation no longer appears as an option on iPhone.
+
 ---
 
 ## v1.7.0 (2026-05-13)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+### バグ修正
+
+- **Apple翻訳失敗時のエラー詳細を UI に表示するよう改善**（#202 / PR #203）
+  - これまで失敗すると `[翻訳失敗]` だけが表示されていたが、ネイティブハンドラからのエラー文字列も付記されるようになり調査しやすくなった
+  - iOS Safari 拡張では Apple Translation が未実装（Extension プロセスが UIWindowScene を持たないため）なのに `appleAvailable = true` になっていた問題を修正。`ping` レスポンスに `translateActionSupported` フラグを追加し、iOS では `false` を返すことで Apple Translation が選択肢に表示されなくなった
+
 ---
 
 ## v1.7.0（2026-05-13）

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -1888,3 +1888,49 @@ suites:
           - 段落 2 の翻訳に `@@DVTPARA@@` の文字列がそのまま残っている（マーカーと混同されない）
           - フォールバック表示（全文 1 ブロック）にならない
 
+
+  - id: apple-translation-error
+    title: Apple翻訳エラー詳細表示
+    description: "PR #203 の修正で、Apple翻訳が失敗したときに汎用メッセージだけでなくエラー詳細も表示されるようになった回帰防止。iOSでは appleAvailable が false になり Apple翻訳が選択肢に出ないことも確認する。"
+    related_prs: [203]
+    scenarios:
+      - id: ATE-001
+        title: macOS Safari でApple翻訳が失敗した場合にエラー詳細が表示される
+        priority: p1
+        environment: safari-mac
+        preconditions:
+          - macOS 15 未満、または Translation framework が利用不可の環境
+          - 翻訳エンジンを Apple に設定済み
+        steps:
+          - Safari で任意のページを開き、テキストを選択して選択翻訳を実行
+        expected:
+          - "[翻訳失敗] — <エラー詳細メッセージ> の形式でエラーが表示される（汎用メッセージだけではない）"
+
+      - id: ATE-002
+        title: iPhone で設定タブに Apple 翻訳が選択肢として表示されない
+        priority: p0
+        environment: safari-ios-sim
+        preconditions:
+          - iOS 18 以上の iPhone / Simulator
+          - DualView Translator Safari 拡張が有効
+        steps:
+          - Safari で DualView Translator のポップアップを開く
+          - 設定タブを開く
+          - 翻訳エンジン選択肢を確認
+        expected:
+          - 翻訳エンジンの選択肢に Apple Translation が表示されない
+          - Google / DeepL のみが表示される
+
+      - id: ATE-003
+        title: macOS Safari で Apple 翻訳が選択肢として表示される
+        priority: p1
+        environment: safari-mac
+        preconditions:
+          - macOS 15 以上の Mac
+          - DualView Translator Safari 拡張が有効
+        steps:
+          - Safari で DualView Translator のポップアップを開く
+          - 設定タブを開く
+          - 翻訳エンジン選択肢を確認
+        expected:
+          - 翻訳エンジンの選択肢に Apple Translation が表示される

--- a/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/safari/DualView Translator/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -162,6 +162,18 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         } else {
             info["languageAvailabilityAPIAvailable"] = false
         }
+        // translate アクション（実テキスト翻訳）は macOS 15+ のみ実装済み。
+        // iOS は Extension プロセスが UIWindowScene を持たないため SwiftUI ホスト戦略が使えず未実装。
+        // background.js 側でこのフラグを見て iOS では appleAvailable を false にする。
+        #if os(macOS)
+        if #available(macOS 15.0, *) {
+            info["translateActionSupported"] = true
+        } else {
+            info["translateActionSupported"] = false
+        }
+        #else
+        info["translateActionSupported"] = false
+        #endif
         return info
     }
 
@@ -416,11 +428,14 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                     "targetMaximalIdentifier": targetLang.maximalIdentifier,
                 ]
             } catch {
+                os_log(.error, "[DVT] Apple Translation failed: %{public}@", error.localizedDescription)
                 return makeError("translation failed: \(error.localizedDescription)")
             }
             #else
             // iOS の Safari Web Extension ハンドラは UIWindowScene を持たないため、
-            // SwiftUI ホスト戦略は使えない。別途 App Group 経由などの戦略が必要（次段階）。
+            // SwiftUI ホスト戦略は使えない。ping の translateActionSupported: false で
+            // background.js 側が appleAvailable を false にするため、ここには到達しないはず。
+            os_log(.error, "[DVT] translate action called on iOS but not implemented (UIWindowScene unavailable in extension process)")
             return makeError("iOS translation not yet implemented (requires App Group bridge to container app)")
             #endif
         }


### PR DESCRIPTION
## Summary

- `content-core.js`: 翻訳失敗時に `res.error` をメッセージに付記するよう変更。`[翻訳失敗] — <エラー詳細>` の形式で表示されるようになり、根本原因の調査が可能になった
- `SafariWebExtensionHandler.swift`: `ping` レスポンスに `translateActionSupported` フラグを追加。iOS では Extension プロセスが UIWindowScene を持たないため `false`、macOS 15+ のみ `true` を返す
- `background.js`: `detectAppleAvailability()` で `translateActionSupported` も判定するよう変更。これにより iOS では `appleAvailable = false` となり、Apple翻訳が翻訳エンジン選択肢に表示されなくなる
- `SafariWebExtensionHandler.swift`: iOS 未実装パスと macOS 失敗パスに `os_log(.error, ...)` を追加し、Console.app で確認できるようにした

## Test plan

- [ ] ATE-001: macOS Safari でApple翻訳が失敗したときに `[翻訳失敗] — <エラー詳細>` が表示されることを確認
- [ ] ATE-002: iOS 18+ の iPhone / Simulator で翻訳エンジン選択肢に Apple Translation が表示されないことを確認
- [ ] ATE-003: macOS 15+ の Mac で翻訳エンジン選択肢に Apple Translation が表示されることを確認

closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)