### PR TITLE
fix: Firefox で領域選択翻訳を Esc キャンセルできない問題を修正

### DIFF
--- a/content-page.js
+++ b/content-page.js
@@ -280,6 +280,9 @@ var DVT_PAGE = (function () {
   function enterRegionMode(mode) {
     const summarize = (mode === 'summarize');
     DVT.state.regionMode = true;
+    // Firefox 対策: ポップアップ閉鎖直後はページ document に focus が戻らず
+    // document への keydown が発火しないため、明示的に window に focus を戻す
+    try { window.focus(); } catch (e) {}
     document.body.style.cursor = 'crosshair';
     let highlightedEl = null;
 
@@ -327,12 +330,14 @@ var DVT_PAGE = (function () {
       hint.remove();
       document.removeEventListener('mousemove', onMousemove);
       document.removeEventListener('click', onClick, true);
-      document.removeEventListener('keydown', onKeydown);
+      window.removeEventListener('keydown', onKeydown, true);
     }
 
     document.addEventListener('mousemove', onMousemove);
     document.addEventListener('click', onClick, true);
-    document.addEventListener('keydown', onKeydown);
+    // Firefox 対策: document への keydown はサイト側で stopPropagation される
+    // ことがあるため window の capture phase で受ける
+    window.addEventListener('keydown', onKeydown, true);
   }
 
   // ─── 領域内要素の抽出（共通処理） ────────────────────────────────────
@@ -568,6 +573,8 @@ var DVT_PAGE = (function () {
   function enterSelectorPickMode(urlPattern) {
     if (DVT.state.regionMode) return;
     DVT.state.regionMode = true;
+    // Firefox 対策: enterRegionMode と同じ理由でページに focus を戻す
+    try { window.focus(); } catch (e) {}
 
     // ヒントバナーを表示
     const hint = document.createElement('div');
@@ -594,7 +601,7 @@ var DVT_PAGE = (function () {
       if (lastHighlighted) lastHighlighted.classList.remove('dvt-region-highlight');
       document.removeEventListener('mouseover', onMouseOver);
       document.removeEventListener('click', onClick, true);
-      document.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keydown', onKeyDown, true);
     }
 
     // ─── CSSセレクタを自動生成 ─────────────────────────────────────
@@ -644,7 +651,8 @@ var DVT_PAGE = (function () {
 
     document.addEventListener('mouseover', onMouseOver);
     document.addEventListener('click', onClick, true);
-    document.addEventListener('keydown', onKeyDown);
+    // Firefox 対策: enterRegionMode と同じ理由で window の capture phase で受ける
+    window.addEventListener('keydown', onKeyDown, true);
   }
 
   return { translatePage, translatePageAndSummarize, undoPageTranslate, enterRegionMode, translateElement, translateAndSummarizeElement, translateClickedElement, translateAndSummarizeClickedElement, enterSelectorPickMode };

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -35,6 +35,9 @@ permalink: /RELEASE_NOTES.en.html
 - **Apple Translation errors now show detail in the UI** (#202 / PR #203)
   - Previously a failed translation just said `[Translation failed]` with no hint of why. Now the error message from the native handler is appended, so you can actually see what went wrong.
   - Fixed a bug where `appleAvailable` was set to `true` on iOS Safari even though the `translate` action isn't implemented there (Extension processes don't have a UIWindowScene). The `ping` response now includes a `translateActionSupported` flag (`false` on iOS), so Apple Translation no longer appears as an option on iPhone.
+- **Fixed Escape not canceling "Pick area to translate" on Firefox** (#211)
+  - When you opened the popup and clicked the area-pick button, keyboard focus stayed in the browser chrome instead of returning to the page, so the `keydown` listener on `document` never fired.
+  - We now call `window.focus()` when entering the mode and listen on `window` with capture, so Escape cancels reliably. Same fix applied to the element picker in the Rules tab.
 
 ---
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -35,6 +35,9 @@ permalink: /RELEASE_NOTES.html
 - **Apple翻訳失敗時のエラー詳細を UI に表示するよう改善**（#202 / PR #203）
   - これまで失敗すると `[翻訳失敗]` だけが表示されていたが、ネイティブハンドラからのエラー文字列も付記されるようになり調査しやすくなった
   - iOS Safari 拡張では Apple Translation が未実装（Extension プロセスが UIWindowScene を持たないため）なのに `appleAvailable = true` になっていた問題を修正。`ping` レスポンスに `translateActionSupported` フラグを追加し、iOS では `false` を返すことで Apple Translation が選択肢に表示されなくなった
+- **Firefox で「領域を選択して翻訳」を Esc キーでキャンセルできない問題を修正**（#211）
+  - ポップアップを閉じた直後はページ document にキーボードフォーカスが戻らないため、`document` への `keydown` リスナーが発火していなかった
+  - モード開始時に `window.focus()` を呼びつつ、`keydown` リスナーを `window` の capture phase に変更して堅牢化。要素ピッカー（ルールタブの「要素を選択」）にも同等の修正を適用
 
 ---
 

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -2149,3 +2149,44 @@ suites:
           - "エラーステータス「このブラウザは sync ストレージに対応していません」または同期エラー"
           - トグルが自動で OFF に戻る
           - ローカル設定は変化しない
+
+  # ━━━━━ 領域選択翻訳の Esc キャンセル（#211 回帰防止） ━━━━━
+  - id: region-mode-escape
+    title: 領域選択翻訳・要素ピッカーの Esc キャンセル
+    description: "Firefox でポップアップから領域選択モードに入った直後の Esc が効かなかった問題（#211）の回帰防止"
+    related_prs: [211]
+    scenarios:
+      - id: REG-001
+        title: Firefox で「領域を選択して翻訳」を Esc でキャンセルできる
+        priority: p1
+        environment: firefox
+        preconditions:
+          - 任意のページを開く
+        steps:
+          - ツールバーから拡張ポップアップを開き「領域を選択して翻訳」をクリック
+          - ページ内をどこもクリックせずに Esc キーを押す
+        expected:
+          - 領域選択モードが解除される（ハイライト・ヒントバナーが消える）
+          - カーソルが crosshair から通常に戻る
+        description: "#211 で報告された Firefox 固有の Esc 無反応バグの回帰防止"
+
+      - id: REG-002
+        title: Chrome で「領域を選択して翻訳」を Esc でキャンセルできる
+        priority: p1
+        environment: chrome
+        steps:
+          - ポップアップから「領域を選択して翻訳」を開始
+          - ページ内をクリックせずに Esc
+        expected:
+          - 領域選択モードが解除される
+        description: "#211 の修正で Chrome に回帰が起きていないかの確認"
+
+      - id: REG-003
+        title: 要素ピッカー（ルールタブ「要素を選択」）も Esc でキャンセルできる
+        priority: p2
+        steps:
+          - ポップアップの「ルール」タブから「要素を選択」をクリック
+          - ページ内をクリックせずに Esc
+        expected:
+          - 要素ピッカーモードが解除される
+          - ハイライト・ヒントバナーが消える

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -2153,8 +2153,8 @@ suites:
   # ━━━━━ 領域選択翻訳の Esc キャンセル（#211 回帰防止） ━━━━━
   - id: region-mode-escape
     title: 領域選択翻訳・要素ピッカーの Esc キャンセル
-    description: "Firefox でポップアップから領域選択モードに入った直後の Esc が効かなかった問題（#211）の回帰防止"
-    related_prs: [211]
+    description: "Firefox でポップアップから領域選択モードに入った直後の Esc が効かなかった問題（Issue #211）の回帰防止"
+    related_prs: [212]
     scenarios:
       - id: REG-001
         title: Firefox で「領域を選択して翻訳」を Esc でキャンセルできる

--- a/tests/content-page.test.js
+++ b/tests/content-page.test.js
@@ -90,8 +90,8 @@ describe('DVT_PAGE (content-page)', () => {
       DVT.state.regionMode = false;
       DVT_PAGE.enterSelectorPickMode('*://example.com/*');
       expect(DVT.state.regionMode).toBe(true);
-      // クリーンアップ: Escapeイベントで終了させる
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      // クリーンアップ: window への Escape イベントで終了させる（Firefox 対策で capture phase）
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
       expect(DVT.state.regionMode).toBe(false);
     });
 
@@ -100,6 +100,33 @@ describe('DVT_PAGE (content-page)', () => {
       // 既存のヒントがない状態でも例外が起きないことを確認
       expect(() => DVT_PAGE.enterSelectorPickMode('*://example.com/*')).not.toThrow();
       DVT.state.regionMode = false;
+    });
+  });
+
+  // Issue #211 回帰防止: Firefox で領域選択モードを Esc キャンセルできない問題
+  describe('enterRegionMode / enterSelectorPickMode — Esc キャンセル（Issue #211）', () => {
+    afterEach(() => {
+      DVT.state.regionMode = false;
+      document.body.style.cursor = '';
+      document.querySelectorAll('.dvt-region-hint').forEach(el => el.remove());
+    });
+
+    it('enterRegionMode: window への Escape keydown でモードが解除される', () => {
+      DVT.state.regionMode = false;
+      DVT_PAGE.enterRegionMode('translate');
+      expect(DVT.state.regionMode).toBe(true);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(DVT.state.regionMode).toBe(false);
+      expect(document.querySelectorAll('.dvt-region-hint').length).toBe(0);
+    });
+
+    it('enterSelectorPickMode: window への Escape keydown でモードが解除される', () => {
+      DVT.state.regionMode = false;
+      DVT_PAGE.enterSelectorPickMode('*://example.com/*');
+      expect(DVT.state.regionMode).toBe(true);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(DVT.state.regionMode).toBe(false);
+      expect(document.querySelectorAll('.dvt-region-hint').length).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

Firefox でポップアップから「領域を選択して翻訳」を起動した直後、ページ内をクリックする前に Esc を押してもキャンセルできなかった問題を修正。

## Root cause

Firefox では拡張ポップアップを閉じてもキーボードフォーカスがブラウザクロームに残り、ページ document に戻らない。そのため `document.addEventListener('keydown', ...)` が一度も発火していなかった（Chrome は popup 閉鎖時にページへ focus が戻るので問題が顕在化していなかった）。

## Changes

- `content-page.js`
  - `enterRegionMode` / `enterSelectorPickMode` の冒頭で `window.focus()` を呼ぶ
  - `keydown` リスナーを `document` → `window` の capture phase (`true`) に変更
- `tests/content-page.test.js`
  - Issue #211 回帰防止テスト 2 件追加（`enterRegionMode` / `enterSelectorPickMode` の Esc キャンセル）
- `docs/manual-test-scenarios.yaml`
  - `region-mode-escape` スイート（REG-001〜003）追加
- `docs/RELEASE_NOTES.md` / `docs/RELEASE_NOTES.en.md`
  - 未リリース → バグ修正に追記

## Test

- `npm test` 全 626 件 PASS
- Chrome: 領域選択翻訳→ Esc でキャンセル動作確認済み
- Firefox: マージ後のリリーステストで REG-001 を実施予定

closes #211