### PR TITLE
chore: .claude/worktrees/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ package-lock.json
 safari/**/xcuserdata/
 safari/**/*.xcuserstate
 safari/**/build/
+
+# Claude Code worktrees（ローカル一時作業ディレクトリ。embedded git repo として誤コミットされやすい）
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Claude Code が isolation 機能で作る一時 worktree（`.claude/worktrees/<name>`）がリポジトリルートからの相対パスで embedded git repo として検出され、`git add -A` のときに誤って commit に巻き込まれる事故が発生したため除外する。

## 経緯

PR #222（Issue #221 対応）の作業中に 2 度ほど誤って `.claude/worktrees/eager-pare-c126de` を commit してしまい、その都度 `git rm --cached` で取り消した。`.gitignore` で根本的に除外する。

## Test plan

- [ ] `git status` に `.claude/worktrees/` が表示されなくなることを確認
- [ ] `git add -A` で `.claude/worktrees/` 配下が staged にならないことを確認

ルール変更系 PR（`.gitignore` は repo-level の chore）のため対応 Issue なし。