### PR TITLE
fix: splitSentences で脚注番号 [n] を挟む英文の文区切りを正しく検出

### DIFF
--- a/content-core.js
+++ b/content-core.js
@@ -113,21 +113,24 @@ var DVT = (function () {
           let j = i + 1;
           while (j < len && /\s/.test(text[j])) j++;
           // Wikipedia 等の脚注番号 [数字] を検出してスキップ
+          // 連続脚注 "[10][11]" や "[10] [11]" にも対応
           // 脚注は前の文への注釈なのでバッファに取り込んでから区切る
           let footnoteEnd = -1;
-          if (text[j] === '[') {
+          while (text[j] === '[') {
             let k = j + 1;
             while (k < len && /\d/.test(text[k])) k++;
-            if (k < len && text[k] === ']') {
+            if (k < len && text[k] === ']' && k > j + 1) {
               footnoteEnd = k;
               j = k + 1;
               while (j < len && /\s/.test(text[j])) j++;
+            } else {
+              break;
             }
           }
           const nextNonSpace = text[j];
           if (nextNonSpace && /[A-Z぀-ゟ゠-ヿ一-鿿]/.test(nextNonSpace)) {
             if (footnoteEnd >= 0) {
-              // 脚注番号をバッファに取り込んでから区切る（例: "sentence. [10]" → 1文目末尾）
+              // 脚注番号をバッファに取り込んでから区切る（例: "sentence. [10][11]" → 1文目末尾）
               buf += text.slice(i + 1, footnoteEnd + 1);
               i = footnoteEnd;
             }

--- a/content-core.js
+++ b/content-core.js
@@ -112,8 +112,25 @@ var DVT = (function () {
           // 後続文の開始文字を確認（空白を読み飛ばす）
           let j = i + 1;
           while (j < len && /\s/.test(text[j])) j++;
+          // Wikipedia 等の脚注番号 [数字] を検出してスキップ
+          // 脚注は前の文への注釈なのでバッファに取り込んでから区切る
+          let footnoteEnd = -1;
+          if (text[j] === '[') {
+            let k = j + 1;
+            while (k < len && /\d/.test(text[k])) k++;
+            if (k < len && text[k] === ']') {
+              footnoteEnd = k;
+              j = k + 1;
+              while (j < len && /\s/.test(text[j])) j++;
+            }
+          }
           const nextNonSpace = text[j];
           if (nextNonSpace && /[A-Z぀-ゟ゠-ヿ一-鿿]/.test(nextNonSpace)) {
+            if (footnoteEnd >= 0) {
+              // 脚注番号をバッファに取り込んでから区切る（例: "sentence. [10]" → 1文目末尾）
+              buf += text.slice(i + 1, footnoteEnd + 1);
+              i = footnoteEnd;
+            }
             parts.push(buf.trim());
             buf = '';
           }

--- a/tests/content-core.test.js
+++ b/tests/content-core.test.js
@@ -95,6 +95,23 @@ describe('DVT (content-core)', () => {
       const out = DVT.splitSentences('A。  B。');
       expect(out).toEqual(['A。', 'B。']);
     });
+
+    it('英語の脚注番号 [n] を挟む文を正しく区切る', () => {
+      // Wikipedia等: ". [10] Next sentence." → 2文に分割
+      expect(DVT.splitSentences('First sentence. [10] Second sentence.'))
+        .toEqual(['First sentence. [10]', 'Second sentence.']);
+    });
+
+    it('脚注番号が複数桁でも正しく区切る', () => {
+      expect(DVT.splitSentences('One sentence. [123] Another sentence.'))
+        .toEqual(['One sentence. [123]', 'Another sentence.']);
+    });
+
+    it('[n] の後が小文字なら区切らない', () => {
+      // [n] 後が小文字の場合は文継続
+      expect(DVT.splitSentences('Some text. [1] continued text.'))
+        .toEqual(['Some text. [1] continued text.']);
+    });
   });
 
   describe('langMatches()', () => {

--- a/tests/content-core.test.js
+++ b/tests/content-core.test.js
@@ -112,6 +112,23 @@ describe('DVT (content-core)', () => {
       expect(DVT.splitSentences('Some text. [1] continued text.'))
         .toEqual(['Some text. [1] continued text.']);
     });
+
+    it('連続脚注 [10][11] (空白なし) を正しく区切る', () => {
+      // Wikipedia 典型ケース: 連続する脚注が空白なしで並ぶ
+      expect(DVT.splitSentences('First sentence. [10][11] Second sentence.'))
+        .toEqual(['First sentence. [10][11]', 'Second sentence.']);
+    });
+
+    it('連続脚注 [10] [11] (空白あり) を正しく区切る', () => {
+      // 連続脚注の間に空白がある場合
+      expect(DVT.splitSentences('First sentence. [10] [11] Second sentence.'))
+        .toEqual(['First sentence. [10] [11]', 'Second sentence.']);
+    });
+
+    it('3つ以上の連続脚注 [1][2][3] にも対応', () => {
+      expect(DVT.splitSentences('First. [1][2][3] Second.'))
+        .toEqual(['First. [1][2][3]', 'Second.']);
+    });
   });
 
   describe('langMatches()', () => {


### PR DESCRIPTION
## Summary

- `content-core.js` の `splitSentences` で、英語の `.` の後に Wikipedia 等の脚注番号 `[数字]` が続く場合、脚注をスキップして次の文字（大文字）で文区切りを正しく判定するよう修正
- 脚注番号はバッファに取り込んでから区切るため、1文目の末尾に自然な形で付く

## Root cause

`"Sentence. [10] Next."` のような英語テキストで、現在の実装は `.` の後の非空白文字 `[` が大文字パターン `/[A-Z...]/` にマッチしないため文区切りを検出できなかった。

一方、日本語訳文では `。` で正しく区切られるため原文・訳文の文数が不一致となり、文ペア表示が `tryRenderPaired` で `false` を返して単一ブロック表示にフォールバックしていた。

## Test plan

- [x] `npm test` — 668 件全パス（新規テスト 3 件追加）
- [ ] Wikipedia 等の英語ページでテキストを選択 → ミニアイコンクリック → 文ペア表示が出ることを確認

closes #238