### PR TITLE
docs(skills): リリースzipにwelcome.html/welcome.jsを追加

### DIFF
--- a/.claude/skills/build-zip.md
+++ b/.claude/skills/build-zip.md
@@ -46,6 +46,8 @@ Chrome Web Store / Firefox Add-ons への提出用。
 - `popup.html`
 - `popup-init.js`
 - `popup.js`
+- `welcome.html`
+- `welcome.js`
 - `icons/`
 - `_locales/`
 - `LICENSE`
@@ -63,6 +65,8 @@ zip -r dualview-translator-<VERSION>.zip \
   popup.html \
   popup-init.js \
   popup.js \
+  welcome.html \
+  welcome.js \
   icons/ \
   _locales/ \
   LICENSE

--- a/.claude/skills/build-zip.md
+++ b/.claude/skills/build-zip.md
@@ -34,6 +34,9 @@ rm -f dualview-translator-*.zip
 Chrome Web Store / Firefox Add-ons への提出用。
 ファイル名: `dualview-translator-<VERSION>.zip`
 
+> **注記**: この一覧は「リリース時点の作業ツリー（= main マージ後）に存在する拡張本体ファイル」を前提とした提出仕様です。`/build-zip` はリリース準備時に main 上で実行するため、ここに挙げたファイルは全て存在している前提でよい。
+> `welcome.html` / `welcome.js` は #245（ツールバーへのピン留め誘導）で追加されるファイルで、#245 が main にマージされて初めて存在する。**#245 マージ前にこのコマンドを実行するとファイル不在で失敗する**ため、必ず #245 マージ後に実行すること。
+
 含めるファイル:
 - `manifest.json`
 - `background.js`


### PR DESCRIPTION
## Summary

PR #245（ピン留め誘導機能）で追加するウェルカムページ `welcome.html` / `welcome.js` を、`/build-zip` スキルの公開用 zip 梱包対象に追加する。

これがないとリリースビルドにウェルカムページが含まれず、初回インストール時に `chrome.tabs.create('welcome.html')` で空白タブが開いてしまう。

スコープ分離ルールに従い、機能 PR #245 とは別の `docs(skills):` PR として分離。

## 依存関係

- #245 のマージとセットで有効になる（先後は問わない）

## Test plan

- [ ] 次回リリース時に `/build-zip` を実行し、生成 zip に `welcome.html` / `welcome.js` が含まれることを `unzip -l` で確認