### PR TITLE
docs(rules): security-guidance プラグインをプロジェクトで有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## Summary

Anthropic 公式の Claude Code プラグイン **security-guidance** をプロジェクトスコープで有効化し、チーム全体に共有する。

- 編集時に XSS・コマンドインジェクション・eval・危険な deserialization 等の脆弱性パターンを自動警告するプラグイン
- プロジェクトルートの `.claude/settings.json`（コミット対象）に `enabledPlugins` を追加
- クローンしたメンバーが信頼フォルダを承認すると、有効化が提案される
- 当リポジトリの XSS 対策（`DVT.escapeHtml()`）・OWASP 意識のコーディング方針と整合

```json
{
  "enabledPlugins": {
    "security-guidance@claude-plugins-official": true
  }
}
```

`security-guidance@claude-plugins-official` は公式マーケットプレイス（追加不要）のプラグイン。識別子は実環境の `/plugin install` 結果で確認済み。

## 補足

- `.claude/` 配下のみの変更のため Issue は紐づけない（スコープ分離ルールに準拠）
- マージは人間が行ってください（Claude はマージしません）