### PR TITLE
feat: Shadow DOM 内コメントの翻訳に対応（Hyvor Talk 等の Web Components 型）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,17 @@ content-*.js → chrome.runtime.sendMessage → background.js → Google Transla
 - セキュリティ: 受信メッセージを `__dvt_relay: true` シグネチャ + 自フレーム送信遮断（`event.source === window`）+ 許可 action リスト（`translatePage` / `translatePageAndSummarize` / `undoPage` / `togglePageTranslate` / `enterRegionMode` / `exitRegionMode`）に限定する。`__dvt_relay` は公開値で postMessage 自体は任意フレームから送れるため、**トップフレームでは postMessage 由来の翻訳系アクションを一切実行しない**（子 iframe のみ実行。トップへの正規 postMessage は子からの `__dvtReady` / `__dvtRegionExitBroadcast` のみ）。これによりホストページが自前で作った子 iframe からトップへ postMessage してページ翻訳を操作する攻撃を防ぐ
 - スコープ: ページ全体翻訳 + 領域選択（要素選択翻訳）。選択テキスト翻訳・コンテキストメニュー翻訳・翻訳バー・自動翻訳ルールは iframe 対象外（OpenWeb / Facebook Comments 等の他コメントシステムも未対応）
 
+### Shadow DOM 貫通翻訳（Hyvor Talk 等の Web Components 型コメント対応）
+
+- Hyvor Talk のようなコメントシステムは cross-origin iframe ではなく **open Shadow DOM** にコメントを直接描画する。通常の `querySelectorAll` は shadow boundary を越えないため、専用の貫通ヘルパーを使う
+- **`DVT.deepQuerySelectorAll(root, selector)` / `DVT.forEachShadowRoot(root, cb)`**（`content-core.js`）: light DOM + 配下の全 open shadow root を再帰的に辿る。`SHADOW_MAX_DEPTH`（12）で再帰深さを制限。closed shadow root は `el.shadowRoot === null` で自然にスキップ
+- **翻訳対象抽出**: `filterTranslatableElements` / `extractRegionElements` を `DVT.deepQuerySelectorAll` 化し、shadow 内コメントも翻訳対象に含める
+- **動的監視**: `startPageObserver` が `observeShadowRoots()` で現存する全 open shadow root も `observe`。`translateNewElements`（デバウンス後）で後から出現した shadow root も監視対象に追加し、遅延ロードのコメントに追従。`observedShadowRoots`（WeakSet）で二重 observe を防ぐ
+- **undo / 復元**: `undoPageTranslate` の `[data-dvt-id]` / `.dvt-summary` 収集を `DVT.deepQuerySelectorAll` 化し、shadow 内の翻訳済み要素も復元
+- **領域選択**: `enterRegionMode` の mousemove / click ハンドラで `eventTarget(e)`（`event.composedPath()[0]` を優先）を使い、retargeting で host になってしまう問題を回避して shadow 内の実要素をハイライト/翻訳
+- **対象外**: 自動翻訳ルールのセレクタ選択（`enterSelectorPickMode`／生成 CSS セレクタは shadow を貫通できず機能しない）、言語検出（`content-bar.js`／shadow 内テキスト未収集）、closed shadow root（JS から到達不可）
+- **既知の制約**: 翻訳結果の表示制御は inline style（`setProperty('display','block','important')` 等）で行うため shadow 内でも機能は動作するが、`content.css` は shadow boundary を越えないため装飾（訳文の色・区切り線等）は未適用。shadow root への style 注入は follow-up
+
 ### 要約エンジン（LLM）
 
 - **Claude**: `api.anthropic.com/v1/messages`（model: claude-haiku-4-5-20251001）

--- a/content-core.js
+++ b/content-core.js
@@ -89,12 +89,18 @@ var DVT = (function () {
 
   // root（Document / Element / ShadowRoot）配下の open shadow root を再帰的に列挙し、
   // 各 shadow root に対して callback を呼ぶ。
+  // querySelectorAll('*') で全要素の NodeList を確保すると大規模 DOM で高コストなため、
+  // TreeWalker で要素を逐次走査して shadow host を見つける（NodeList を生成しない）。
   function forEachShadowRoot(root, callback, _depth = 0) {
-    if (_depth > SHADOW_MAX_DEPTH || !root || typeof root.querySelectorAll !== 'function') return;
-    let all;
-    try { all = root.querySelectorAll('*'); } catch (e) { return; }
-    for (const el of all) {
-      const sr = el.shadowRoot;
+    if (_depth > SHADOW_MAX_DEPTH || !root) return;
+    // ShadowRoot/DocumentFragment は createTreeWalker を持たないため owner document 経由で生成する
+    const doc = (root.nodeType === 9 /* Document */) ? root : (root.ownerDocument || document);
+    let walker;
+    try {
+      walker = doc.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+    } catch (e) { return; }
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const sr = node.shadowRoot;
       if (sr) {
         callback(sr);
         forEachShadowRoot(sr, callback, _depth + 1);

--- a/content-core.js
+++ b/content-core.js
@@ -81,6 +81,38 @@ var DVT = (function () {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
+  // ─── Shadow DOM 貫通ユーティリティ ──────────────────────────────────
+  // Hyvor Talk 等の Web Components 型コメントは open Shadow DOM 内に描画される。
+  // 通常の querySelectorAll は shadow boundary を越えないため、open shadow root を
+  // 再帰的に辿るヘルパーを用意する（closed shadow root は shadowRoot===null で自然にスキップ）。
+  const SHADOW_MAX_DEPTH = 12; // 再帰の深さ上限（無限ループ・過剰探索の防止）
+
+  // root（Document / Element / ShadowRoot）配下の open shadow root を再帰的に列挙し、
+  // 各 shadow root に対して callback を呼ぶ。
+  function forEachShadowRoot(root, callback, _depth = 0) {
+    if (_depth > SHADOW_MAX_DEPTH || !root || typeof root.querySelectorAll !== 'function') return;
+    let all;
+    try { all = root.querySelectorAll('*'); } catch (e) { return; }
+    for (const el of all) {
+      const sr = el.shadowRoot;
+      if (sr) {
+        callback(sr);
+        forEachShadowRoot(sr, callback, _depth + 1);
+      }
+    }
+  }
+
+  // light DOM + 配下の全 open shadow root を貫通して selector にマッチする要素を返す。
+  function deepQuerySelectorAll(root, selector) {
+    const results = [];
+    if (!root || typeof root.querySelectorAll !== 'function') return results;
+    try { root.querySelectorAll(selector).forEach(el => results.push(el)); } catch (e) { /* 不正セレクタ等 */ }
+    forEachShadowRoot(root, (sr) => {
+      try { sr.querySelectorAll(selector).forEach(el => results.push(el)); } catch (e) { /* noop */ }
+    });
+    return results;
+  }
+
   // テキストを文単位に分割する。
   // - CJK の文末記号（`。` / `．` / `！` / `？`）の直後で常に分割
   //   （読点 `、` は文の途切れではないので分割対象に含めない）
@@ -599,6 +631,8 @@ var DVT = (function () {
     langMatches,
     escapeHtml,
     splitSentences,
+    deepQuerySelectorAll,
+    forEachShadowRoot,
     showToast,
     updateToast,
     getLangDisplayName,

--- a/content-page.js
+++ b/content-page.js
@@ -329,7 +329,8 @@ var DVT_PAGE = (function () {
 
   // ─── 翻訳可能な要素のフィルタリング ────────────────────────────────
   function filterTranslatableElements(container, selectors) {
-    return Array.from(container.querySelectorAll(selectors || PAGE_SELECTORS)).filter(el => {
+    // Shadow DOM 内（Hyvor Talk 等のコメント）も貫通して翻訳対象を集める。
+    return DVT.deepQuerySelectorAll(container, selectors || PAGE_SELECTORS).filter(el => {
       if (el.closest('[data-dvt]')) return false;
       if (el.dataset.dvtId) return false;
       const text = el.innerText?.trim();
@@ -386,6 +387,20 @@ var DVT_PAGE = (function () {
   // ─── 動的コンテンツ監視（MutationObserver） ────────────────────────
   let pageObserver = null;
   let observerDebounceTimer = null;
+  // 監視済み shadow root を記録し、同一 root の二重 observe を避ける
+  let observedShadowRoots = new WeakSet();
+
+  // 現存する全 open shadow root を pageObserver の監視対象に追加する。
+  // Hyvor Talk 等のコメントは shadow root 内で動的に増えるため、light DOM の
+  // subtree 監視だけでは捕捉できない変更を拾えるようにする。
+  function observeShadowRoots() {
+    if (!pageObserver) return;
+    DVT.forEachShadowRoot(document, (sr) => {
+      if (observedShadowRoots.has(sr)) return;
+      observedShadowRoots.add(sr);
+      pageObserver.observe(sr, { childList: true, subtree: true });
+    });
+  }
 
   function startPageObserver(tl) {
     if (pageObserver) return;
@@ -400,6 +415,8 @@ var DVT_PAGE = (function () {
       childList: true,
       subtree: true,
     });
+    // 既存の open shadow root も監視（後から出現する分は translateNewElements で追加）
+    observeShadowRoots();
   }
 
   function stopPageObserver() {
@@ -411,11 +428,15 @@ var DVT_PAGE = (function () {
       clearTimeout(observerDebounceTimer);
       observerDebounceTimer = null;
     }
+    // 次回 start 時に再構築するため監視済み記録をリセット
+    observedShadowRoots = new WeakSet();
   }
 
   // 未翻訳の新規要素のみ翻訳
   async function translateNewElements(tl) {
     if (!DVT.state.pageTranslateActive) return;
+    // 後から出現した shadow root（遅延ロードのコメント等）も監視対象に追加
+    observeShadowRoots();
     const elements = filterTranslatableElements(document);
     if (elements.length === 0) return;
     await runConcurrentTranslation(elements, tl, 'dvt-');
@@ -475,12 +496,23 @@ var DVT_PAGE = (function () {
     // 要約ブロックを全削除（ページ全体翻訳の #dvt-page-summary だけでなく、
     // 領域選択翻訳・右クリック翻訳由来の .dvt-summary もまとめて撤去する）。
     // ホストページが偶然 .dvt-summary を使っていても消さないよう [data-dvt="true"] でスコープ
-    document.querySelectorAll('[data-dvt="true"].dvt-summary').forEach(el => el.remove());
+    // Shadow DOM 内（Hyvor Talk 等）の要約ブロックも貫通して撤去
+    DVT.deepQuerySelectorAll(document, '[data-dvt="true"].dvt-summary').forEach(el => el.remove());
     // 翻訳済み要素は原文を復元、dvt-pending だけの要素もマークだけ削除（restoreOriginalContent が両方扱う）
-    document.querySelectorAll('[data-dvt-id]').forEach(el => {
+    // Shadow DOM 内の翻訳済み要素も対象にする
+    DVT.deepQuerySelectorAll(document, '[data-dvt-id]').forEach(el => {
       restoreOriginalContent(el);
     });
     DVT.showToast(t('toastReset'), false, TOAST_SHORT_DURATION_MS);
+  }
+
+  // Shadow DOM 内でのクリック/ホバーは event retargeting により e.target が
+  // shadow host になるため、composedPath() の先頭（実際のターゲット要素）を優先する。
+  // composed イベント（click/mousemove 等）でのみ shadow boundary を越える。
+  function eventTarget(e) {
+    const path = (typeof e.composedPath === 'function') ? e.composedPath() : null;
+    const t = (path && path.length) ? path[0] : e.target;
+    return (t && t.nodeType === 1) ? t : null; // 要素ノードのみ
   }
 
   // ─── 要素クリック選択翻訳 ────────────────────────────────────────────
@@ -508,10 +540,10 @@ var DVT_PAGE = (function () {
     hint.textContent = t(summarize ? 'regionHintSummarize' : 'regionHint');
     document.body.appendChild(hint);
 
-    // ホバー中の要素をハイライト
+    // ホバー中の要素をハイライト（Shadow DOM 内の要素も composedPath で取得）
     function onMousemove(e) {
-      const target = e.target;
-      if (target.closest('[data-dvt]')) return;
+      const target = eventTarget(e);
+      if (!target || target.closest('[data-dvt]')) return;
       if (target === highlightedEl) return;
       if (highlightedEl) highlightedEl.classList.remove('dvt-region-highlight');
       highlightedEl = target;
@@ -520,10 +552,10 @@ var DVT_PAGE = (function () {
 
     // クリックで要素を確定して翻訳（＆要約）
     function onClick(e) {
-      if (e.target.closest('[data-dvt]')) return;
+      const targetEl = eventTarget(e);
+      if (!targetEl || targetEl.closest('[data-dvt]')) return;
       e.preventDefault();
       e.stopPropagation();
-      const targetEl = e.target;
       exitRegionMode();
       if (summarize) {
         translateAndSummarizeClickedElement(targetEl);
@@ -576,7 +608,7 @@ var DVT_PAGE = (function () {
   function extractRegionElements(container) {
     if (!container || container === document.body) return null;
 
-    let elements = Array.from(container.querySelectorAll(REGION_SELECTORS)).filter(el => {
+    let elements = DVT.deepQuerySelectorAll(container, REGION_SELECTORS).filter(el => {
       if (el.closest('[data-dvt]')) return false;
       if (el.dataset.dvtId) return false;
       return el.innerText?.trim().length >= MIN_TEXT_LENGTH;

--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -12,6 +12,11 @@ permalink: /RELEASE_NOTES.en.html
 
 ### New Features
 
+- **Translate comments rendered in Shadow DOM** (#252)
+  - Adds support for Web Components comment systems (open Shadow DOM) like Hyvor Talk. We found in real-world testing that lots of modern comment systems render straight into Shadow DOM rather than a cross-origin iframe like Disqus, so we handle that now.
+  - The content script walks `shadowRoot` recursively to find, watch, and restore translatable elements (`deepQuerySelectorAll`). Whole-page translation, region select, undo, and dynamic-content watching all pierce Shadow DOM.
+  - Region select uses `composedPath()` to highlight/translate the real element inside the shadow tree (not the host).
+  - Out of scope: auto-rule selector picking (you can't write a CSS selector that crosses a shadow boundary) and closed Shadow DOM (unreachable from JS by spec). Decoration CSS isn't applied inside shadow trees yet, but the feature works.
 - **Translate Disqus iframe comments** (#250)
   - The extension now injects its content script into `https://disqus.com/embed/comments/*` iframes too, so comment sections on Disqus-powered sites (carscoops, etc.) get translated.
   - Works with both **whole-page translation** and **region select (element pick)**. In region-select mode each frame enters picking independently, so you can click a Disqus comment to translate it — and confirming or canceling in any frame clears the mode everywhere.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,6 +12,11 @@ permalink: /RELEASE_NOTES.html
 
 ### 新機能
 
+- **Shadow DOM 内コメントの翻訳に対応**（#252）
+  - Hyvor Talk など Web Components（open Shadow DOM）型のコメントシステムを翻訳対象に追加。実機検証で carscoops の Disqus のような iframe 型ではなく Shadow DOM 直接描画型が多いと判明したため対応
+  - content script が `shadowRoot` を再帰的に辿って翻訳対象を抽出・監視・復元（`deepQuerySelectorAll`）。ページ全体翻訳・領域選択（要素選択翻訳）・undo・動的コンテンツ監視が Shadow DOM を貫通
+  - 領域選択は `composedPath()` で Shadow 内の実要素を正しくハイライト/翻訳
+  - スコープ外: 自動翻訳ルールのセレクタ選択（Shadow を貫通する CSS セレクタを作れないため）・closed Shadow DOM（仕様上 JS から到達不可）。Shadow 内では装飾 CSS が未適用（機能は動作）
 - **Disqus iframe 内コメントの翻訳に対応**（#250）
   - `https://disqus.com/embed/comments/*` の iframe 内にも content script を注入し、carscoops 等 Disqus 採用サイトのコメント欄を翻訳対象に追加
   - **ページ全体翻訳**と**領域選択（要素選択翻訳）**の両方に対応。領域選択では各フレームが独立にモードへ入り、Disqus コメント欄をクリックして翻訳できる（どのフレームで確定／キャンセルしても全フレームのモードが解除される）

--- a/docs/manual-test-scenarios.yaml
+++ b/docs/manual-test-scenarios.yaml
@@ -2663,3 +2663,70 @@ suites:
     known_limitations:
       - "iframe 内では選択テキスト翻訳・コンテキストメニュー翻訳・翻訳バー・自動翻訳ルールは動作しない（対応はページ全体翻訳と領域選択のみ）"
       - "OpenWeb (SpotIM) / Facebook Comments / livefyre 等の他コメントシステムは未対応"
+
+  - id: shadow-dom
+    title: Shadow DOM 内コメントの翻訳
+    description: "PR で追加（#252）。Hyvor Talk 等 open Shadow DOM 型コメントを翻訳対象にする"
+    related_prs: [253]
+    scenarios:
+      - id: SD-001
+        title: Hyvor Talk コメントがページ全体翻訳で翻訳される
+        priority: p1
+        environment: chrome
+        preconditions:
+          - 翻訳エンジンが Google Translate に設定済み
+          - Hyvor Talk コメントを含むページ（例 hyvor.com のブログ記事）を開く
+          - 記事下部までスクロールしてコメントを描画させる
+        steps:
+          - ポップアップを開き翻訳先を日本語にしてページ全体翻訳ボタンを押す
+          - コメント欄まで再度スクロールする
+        expected:
+          - 記事本文に加え Shadow DOM 内のコメント本文も原文と訳文が並んで表示される
+          - 元に戻すボタンで本文・コメント両方が原文に戻る
+        known_limitations:
+          - "Shadow DOM 内では content.css が適用されないため訳文の色・区切り線等の装飾は付かない（テキストは表示される）"
+
+      - id: SD-002
+        title: 領域選択で Shadow DOM 内コメントをクリック翻訳できる
+        priority: p1
+        environment: chrome
+        description: "composedPath() で shadow host ではなく実要素を確定する"
+        preconditions:
+          - Hyvor Talk コメントを含むページを開きコメントを描画させる
+        steps:
+          - ポップアップまたは Ctrl+Shift+R で領域選択モードに入る
+          - Shadow DOM 内のコメント要素にカーソルを合わせる
+          - コメント要素をクリックする
+        expected:
+          - ホバー時に shadow host 全体ではなく個々のコメント要素がハイライトされる
+          - クリックしたコメントが翻訳され原文と訳文が並ぶ
+
+      - id: SD-003
+        title: 遅延ロード／返信追加された Shadow 内コメントにも追従する
+        priority: p2
+        environment: chrome
+        description: "MutationObserver が shadow root を監視し新規コメントを翻訳"
+        preconditions:
+          - Hyvor Talk コメントを含むページでページ全体翻訳が有効
+        steps:
+          - ページ翻訳を有効にした状態で新しいコメントを投稿する、または「もっと見る」で追加コメントを読み込む
+        expected:
+          - 追加されたコメントも自動的に翻訳される（500ms デバウンス後）
+
+      - id: SD-004
+        title: 自動翻訳ルールは Shadow DOM 内要素を対象にできない（仕様）
+        priority: p2
+        environment: chrome
+        description: "生成 CSS セレクタが shadow を貫通できないためルールのセレクタ選択は対象外"
+        preconditions:
+          - Hyvor Talk コメントを含むページを開く
+        steps:
+          - ルールタブのセレクタ選択（領域ピッカー）で Shadow 内コメントを選ぼうとする
+        expected:
+          - shadow host までしか選べない、または生成セレクタが機能しないことを確認（仕様どおり）
+        known_issue: true
+
+    known_limitations:
+      - "closed Shadow DOM は JS から到達不可のため翻訳できない"
+      - "Shadow DOM 内は content.css 非適用のため装飾なし（機能は動作）"
+      - "言語検出（翻訳バー）は Shadow 内テキストを収集しない"

--- a/tests/content-page.test.js
+++ b/tests/content-page.test.js
@@ -562,30 +562,25 @@ describe('DVT_PAGE (content-page)', () => {
   });
 
   describe('undoPageTranslate — 領域選択時の要約ブロックも撤去（#134）', () => {
-    const { readFileSync } = require('fs');
-    const { resolve } = require('path');
-    const code = readFileSync(resolve(__dirname, '..', 'content-page.js'), 'utf-8');
-
-    it('undoPageTranslate は ID 指定ではなくクラス指定で .dvt-summary 全削除する（拡張挿入要素に限定）', () => {
-      // ホストページの偶然の同名クラス汚染を避けるため [data-dvt="true"] でスコープ
-      expect(code).toMatch(/undoPageTranslate[\s\S]{0,400}querySelectorAll\([^)]*data-dvt[^)]*dvt-summary/);
-    });
-
-    it('undoPageTranslate 実行で document 上の .dvt-summary が消える（jsdom 統合）', () => {
-      // 領域選択翻訳の要約ブロック（ID なし）と data-dvt-id を持つ翻訳要素を仕込む
+    it('undoPageTranslate 実行で拡張挿入の .dvt-summary が消え、ホスト汚染分は残る（jsdom 統合）', () => {
+      // 領域選択翻訳の要約ブロック（data-dvt 付き）と data-dvt-id を持つ翻訳要素、
+      // さらにホストページが偶然 .dvt-summary を使っているケース（data-dvt なし）を仕込む
       document.body.innerHTML = `
         <div class="dvt-summary" data-dvt="true">
           <span class="dvt-badge dvt-badge-summary">要約</span>
           <div class="dvt-summary-text">サンプル要約</div>
         </div>
+        <div class="dvt-summary">ホストページが偶然使っている同名クラス</div>
         <p data-dvt-id="dvt-r-1">
           <span class="dvt-orig">Original</span>
           <span class="dvt-trans">翻訳</span>
         </p>
       `;
-      expect(document.querySelectorAll('.dvt-summary').length).toBe(1);
+      expect(document.querySelectorAll('.dvt-summary').length).toBe(2);
       DVT_PAGE.undoPageTranslate();
-      expect(document.querySelectorAll('.dvt-summary').length).toBe(0);
+      // data-dvt="true" の要約ブロックのみ削除され、ホスト汚染分は残る
+      expect(document.querySelectorAll('.dvt-summary').length).toBe(1);
+      expect(document.querySelector('.dvt-summary[data-dvt="true"]')).toBeNull();
       expect(document.querySelectorAll('[data-dvt-id]').length).toBe(0);
     });
   });

--- a/tests/shadow-dom.test.js
+++ b/tests/shadow-dom.test.js
@@ -1,0 +1,227 @@
+// Shadow DOM 貫通翻訳のテスト（#252）
+// Hyvor Talk 等の open Shadow DOM 内コメントを翻訳対象にする機構を検証する。
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+// data-dvt-id を持つ翻訳済み要素（.dvt-orig / .dvt-trans）を DOM API で構築する。
+// （innerHTML は使わない方針）
+function makeTranslatedP(id, origText, transText) {
+  const p = document.createElement('p');
+  p.setAttribute('data-dvt-id', id);
+  const orig = document.createElement('span');
+  orig.className = 'dvt-orig';
+  orig.textContent = origText;
+  const trans = document.createElement('span');
+  trans.className = 'dvt-trans';
+  trans.textContent = transText;
+  p.append(orig, trans);
+  return p;
+}
+
+function makeSummaryBlock() {
+  const div = document.createElement('div');
+  div.className = 'dvt-summary';
+  div.setAttribute('data-dvt', 'true');
+  div.textContent = '要約ブロック';
+  return div;
+}
+
+describe('DVT.deepQuerySelectorAll / forEachShadowRoot（content-core）', () => {
+  beforeAll(() => {
+    loadScript('i18n.js', 'content-core.js');
+  });
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('light DOM のマッチを返す（従来どおり）', () => {
+    const p = document.createElement('p');
+    p.textContent = 'light';
+    document.body.appendChild(p);
+    const hits = DVT.deepQuerySelectorAll(document, 'p');
+    expect(hits.length).toBe(1);
+    expect(hits[0]).toBe(p);
+  });
+
+  it('open shadow root 内のマッチも貫通して返す', () => {
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'open' });
+    const p = document.createElement('p');
+    p.textContent = 'shadow comment';
+    sr.appendChild(p);
+    document.body.appendChild(host);
+
+    // 通常の querySelectorAll は shadow を貫通しない
+    expect(document.querySelectorAll('p').length).toBe(0);
+    // deepQuerySelectorAll は貫通する
+    const hits = DVT.deepQuerySelectorAll(document, 'p');
+    expect(hits.length).toBe(1);
+    expect(hits[0].textContent).toBe('shadow comment');
+  });
+
+  it('light + shadow の両方を合算して返す', () => {
+    const lp = document.createElement('p');
+    lp.textContent = 'light';
+    document.body.appendChild(lp);
+
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'open' });
+    const sp = document.createElement('p');
+    sp.textContent = 'shadow';
+    sr.appendChild(sp);
+    document.body.appendChild(host);
+
+    const hits = DVT.deepQuerySelectorAll(document, 'p');
+    expect(hits.length).toBe(2);
+    expect(hits.map(e => e.textContent).sort()).toEqual(['light', 'shadow']);
+  });
+
+  it('ネストした shadow root も再帰的に辿る', () => {
+    const outer = document.createElement('div');
+    const osr = outer.attachShadow({ mode: 'open' });
+    const inner = document.createElement('div');
+    osr.appendChild(inner);
+    const isr = inner.attachShadow({ mode: 'open' });
+    const p = document.createElement('p');
+    p.textContent = 'deep';
+    isr.appendChild(p);
+    document.body.appendChild(outer);
+
+    const hits = DVT.deepQuerySelectorAll(document, 'p');
+    expect(hits.length).toBe(1);
+    expect(hits[0].textContent).toBe('deep');
+  });
+
+  it('closed shadow root は到達できないため無視される（仕様どおり）', () => {
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'closed' });
+    const p = document.createElement('p');
+    p.textContent = 'closed';
+    sr.appendChild(p);
+    document.body.appendChild(host);
+    // closed は host.shadowRoot === null のため拾えない（クラッシュしないこと）
+    const hits = DVT.deepQuerySelectorAll(document, 'p');
+    expect(hits.length).toBe(0);
+  });
+
+  it('forEachShadowRoot は全 open shadow root を列挙する', () => {
+    const h1 = document.createElement('div');
+    h1.attachShadow({ mode: 'open' });
+    const h2 = document.createElement('div');
+    h2.attachShadow({ mode: 'open' });
+    document.body.append(h1, h2);
+
+    const roots = [];
+    DVT.forEachShadowRoot(document, sr => roots.push(sr));
+    expect(roots.length).toBe(2);
+    expect(roots).toContain(h1.shadowRoot);
+    expect(roots).toContain(h2.shadowRoot);
+  });
+});
+
+describe('DVT_PAGE — Shadow DOM 貫通翻訳（#252）', () => {
+  beforeAll(() => {
+    loadScript('i18n.js', 'content-core.js', 'content-page.js');
+  });
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    DVT.state.pageTranslateActive = false;
+  });
+
+  it('deepQuerySelectorAll で shadow 内の翻訳対象段落も拾える（Hyvor Talk 構造）', () => {
+    const lp = document.createElement('p');
+    lp.textContent = 'This is a light DOM paragraph.';
+    document.body.appendChild(lp);
+
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'open' });
+    const c1 = document.createElement('p');
+    c1.textContent = 'Great insight, thanks!';
+    const c2 = document.createElement('p');
+    c2.textContent = 'I totally agree with this.';
+    sr.append(c1, c2);
+    document.body.appendChild(host);
+
+    const hits = DVT.deepQuerySelectorAll(document, 'p');
+    expect(hits.length).toBe(3);
+  });
+
+  it('undoPageTranslate は shadow root 内の翻訳済み要素・要約も復元/撤去する', () => {
+    // shadow 内に要約ブロックと翻訳済み要素
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'open' });
+    sr.append(makeSummaryBlock(), makeTranslatedP('dvt-r-shadow-1', 'Original comment', '翻訳されたコメント'));
+    document.body.appendChild(host);
+
+    // light DOM 側にも翻訳済み要素1件
+    document.body.appendChild(makeTranslatedP('dvt-r-light-1', 'Light original', 'ライト翻訳'));
+
+    expect(DVT.deepQuerySelectorAll(document, '[data-dvt-id]').length).toBe(2);
+    DVT_PAGE.undoPageTranslate();
+    // shadow 内・light 両方の翻訳済み要素が復元され data-dvt-id が消える
+    expect(DVT.deepQuerySelectorAll(document, '[data-dvt-id]').length).toBe(0);
+    // shadow 内の要約ブロックも撤去される
+    expect(DVT.deepQuerySelectorAll(document, '.dvt-summary').length).toBe(0);
+  });
+});
+
+describe('DVT_PAGE — 領域選択の composedPath 対応（#252）', () => {
+  beforeAll(() => {
+    loadScript('i18n.js', 'content-core.js', 'content-page.js');
+  });
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    DVT.state.regionMode = false;
+    DVT_PAGE.exitRegionMode(true); // 残存モードを解除
+  });
+
+  it('ホバー時、composedPath()[0] の実要素（shadow 内）をハイライトする（e.target の host ではなく）', () => {
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'open' });
+    const comment = document.createElement('p');
+    comment.textContent = 'Shadow comment to translate';
+    sr.appendChild(comment);
+    document.body.appendChild(host);
+
+    DVT_PAGE.enterRegionMode('translate');
+    try {
+      // document に登録された onMousemove へ届くよう document.dispatchEvent（e.target は document）。
+      // composedPath()[0] を shadow 内 comment に固定 → eventTarget が composedPath を使えば comment が拾われる。
+      // もし e.target（=document）を見ていれば要素ノードでないため何もハイライトされない。
+      const ev = new MouseEvent('mousemove', { bubbles: true });
+      Object.defineProperty(ev, 'composedPath', {
+        value: () => [comment, sr, host, document.body, document.documentElement, document],
+      });
+      document.dispatchEvent(ev);
+
+      // composedPath 経由で shadow 内 comment にハイライトクラスが付く
+      expect(comment.classList.contains('dvt-region-highlight')).toBe(true);
+    } finally {
+      DVT_PAGE.exitRegionMode(true);
+    }
+  });
+
+  it('クリック確定で領域選択モードが解除される（composed イベント経由）', () => {
+    const host = document.createElement('div');
+    const sr = host.attachShadow({ mode: 'open' });
+    const comment = document.createElement('p');
+    comment.textContent = 'Shadow comment';
+    sr.appendChild(comment);
+    document.body.appendChild(host);
+
+    DVT_PAGE.enterRegionMode('translate');
+    expect(DVT.state.regionMode).toBe(true);
+
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'composedPath', {
+      value: () => [comment, sr, host, document.body, document.documentElement, document],
+    });
+    document.dispatchEvent(ev);
+
+    // composedPath で実要素が取れ、クリックが確定処理に進む → モード解除
+    expect(DVT.state.regionMode).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Hyvor Talk などモダンなコメントシステムは cross-origin iframe ではなく **open Shadow DOM** にコメントを直接描画する（実機検証で確認）。現状の翻訳は light DOM 専用（`querySelectorAll` は shadow を貫通しない）のため、Shadow DOM 貫通翻訳を実装した。

## 実機検証

hyvor.com のブログ記事（Hyvor Talk 採用）で、実装ロジックが Shadow DOM 内コメント本文（"testing 2 😃" 等）を翻訳対象として正しく抽出できることを確認済み（翻訳対象91件中 shadow 内9件）。

## 主な変更

| ファイル | 内容 |
|---|---|
| `content-core.js` | `deepQuerySelectorAll(root, sel)` / `forEachShadowRoot(root, cb)` を追加し DVT に公開。open shadow root を再帰的に辿る（`SHADOW_MAX_DEPTH=12`、closed は `shadowRoot===null` で自然スキップ） |
| `content-page.js` | `filterTranslatableElements` / `extractRegionElements` を deep query 化。`startPageObserver` が全 open shadow root も `observe`（新規 shadow root にも追従、WeakSet で二重防止）。`undoPageTranslate` の `[data-dvt-id]` / `.dvt-summary` 収集を deep query 化。`enterRegionMode` を `composedPath()`（`eventTarget` ヘルパー）対応 |
| `tests/shadow-dom.test.js` | 新規。deep query / forEachShadowRoot / undo / composedPath ハイライトを jsdom の `attachShadow` で検証 |
| `tests/content-page.test.js` | #134 の grep テストを実 DOM テストに改善（ホスト汚染 `.dvt-summary` が残ることを検証） |

## スコープ

- **対象**: ページ全体翻訳・領域選択（要素選択翻訳）・undo・動的監視の Shadow DOM 貫通
- **対象外**:
  - 自動翻訳ルールのセレクタ選択（`enterSelectorPickMode`）— 生成 CSS セレクタが shadow を貫通できず機能しないため
  - 言語検出（`content-bar.js`）— shadow 内テキスト未収集
  - closed Shadow DOM — JS から到達不可（仕様）

## 既知の制約（follow-up 候補）

翻訳結果の表示は inline style（`setProperty('display','block','important')` 等）で制御するため **shadow 内でも機能は動作する**が、`content.css` は shadow boundary を越えないため装飾（訳文の色・区切り線等）は未適用。shadow root への style 注入は follow-up。

## Test plan

- [x] `npm test` 全件パス（829 件）
- [x] 実機: Hyvor Talk ページで deep query が shadow 内コメントを抽出することを確認
- [ ] 手動 SD-001（ページ翻訳で Hyvor Talk コメントが訳される）
- [ ] 手動 SD-002（領域選択で shadow 内コメントをクリック翻訳）
- [ ] 手動 SD-003（遅延ロードコメントに追従）

closes #252