### PR TITLE
chore: v1.8.0 リリース準備

### DIFF
--- a/docs/RELEASE_NOTES.en.md
+++ b/docs/RELEASE_NOTES.en.md
@@ -10,6 +10,10 @@ permalink: /RELEASE_NOTES.en.html
 
 ## Unreleased
 
+---
+
+## v1.8.0 (2026-06-09)
+
 ### New Features
 
 - **Translate comments rendered in Shadow DOM** (#252)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,6 +10,10 @@ permalink: /RELEASE_NOTES.html
 
 ## 未リリース
 
+---
+
+## v1.8.0（2026-06-09）
+
 ### 新機能
 
 - **Shadow DOM 内コメントの翻訳に対応**（#252）

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "DualView Translator",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dualview-translator",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "原文と翻訳を**並べて表示**するブラウザ翻訳拡張。Chrome / Firefox 対応。",
   "main": "background.js",
   "directories": {

--- a/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
+++ b/safari/DualView Translator/DualView Translator.xcodeproj/project.pbxproj
@@ -866,7 +866,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -878,7 +878,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -901,7 +901,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
@@ -913,7 +913,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -939,7 +939,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -982,7 +982,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
@@ -998,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1024,7 +1024,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1049,7 +1049,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1097,7 +1097,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1122,7 +1122,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1140,7 +1140,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "DualView Translator (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1185,7 +1185,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1210,7 +1210,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (iOS)/DualView Share Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DualView Share Extension (iOS)/Info.plist";
@@ -1222,7 +1222,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				SDKROOT = iphoneos;
@@ -1241,7 +1241,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (iOS)/DualView Share Extension (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DualView Share Extension (iOS)/Info.plist";
@@ -1253,7 +1253,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				SDKROOT = iphoneos;
@@ -1274,7 +1274,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (macOS)/DualView Share Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1288,7 +1288,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				REGISTER_APP_GROUPS = YES;
@@ -1308,7 +1308,7 @@
 				CODE_SIGN_ENTITLEMENTS = "DualView Share Extension (macOS)/DualView Share Extension (macOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 44L2GC4R8F;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1322,7 +1322,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.orangesoft.dualview-translator.ShareExtension";
 				PRODUCT_NAME = "DualView Share Extension";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

- `manifest.json` / `package.json`: バージョンを **1.8.0** に更新
- Xcode `project.pbxproj`: `MARKETING_VERSION` 1.7.1→1.8.0（12箇所）、`CURRENT_PROJECT_VERSION` 10→11（12箇所）
- `docs/RELEASE_NOTES.md` / `.en.md`: 「未リリース」を v1.8.0（2026-06-09）としてまとめ、未リリース枠は空欄で常設

## v1.8.0 の主な変更

### 新機能
- **Shadow DOM 内コメントの翻訳に対応**（#252）— Hyvor Talk 等の Web Components（open Shadow DOM）型コメントを翻訳対象に追加
- **Disqus iframe 内コメントの翻訳に対応**（#250）— cross-origin iframe 内のコメントをページ翻訳・領域選択で翻訳
- **インストール時にツールバーへのピン留めを誘導**（#244 / #247）

### バグ修正
- 複数行選択時のミニアイコン位置ずれ（#240）、ペア表示の縦バー/背景色の回り込み（#228 / #230）、領域選択時の line-clamp で原文が隠れる問題（#222）等

### 改善
- ミニアイコンのデザイン刷新（#235）、選択翻訳パネルの文ペア表示（#233）、ミニアイコンクリックで即時翻訳（#234）等

※ 詳細は `docs/RELEASE_NOTES.md` の v1.8.0 セクション参照

## テスト
- `npm test`: 829 件 全パス